### PR TITLE
Output absolute paths in edgedb server info

### DIFF
--- a/src/portable/server/info.rs
+++ b/src/portable/server/info.rs
@@ -4,7 +4,6 @@ use edgedb_cli_derive::IntoArgs;
 use crate::portable::local;
 use crate::portable::repository::{Channel, Query, QueryOptions};
 use crate::portable::ver;
-use crate::print::AsRelativeToCurrentDir;
 use crate::table;
 
 pub fn run(cmd: &Command) -> anyhow::Result<()> {
@@ -40,7 +39,7 @@ pub fn run(cmd: &Command) -> anyhow::Result<()> {
                     let path = path.to_str().context("cannot convert path to a string")?;
                     println!("{}", serde_json::to_string(path)?);
                 } else {
-                    println!("{}", path.as_relative().display());
+                    println!("{}", path.display());
                 }
             }
             "version" => {
@@ -64,10 +63,7 @@ pub fn run(cmd: &Command) -> anyhow::Result<()> {
     } else {
         table::settings(&[
             ("Version", inst.version.to_string()),
-            (
-                "Binary path",
-                inst.server_path()?.as_relative().display().to_string(),
-            ),
+            ("Binary path", inst.server_path()?.display().to_string()),
         ]);
     }
     Ok(())


### PR DESCRIPTION
It was changed to output relative paths in #1447, which is probably
not what we want. It is specifically a problem because it is used
by some downstream scripts to create symlinks, which broke.