### PR TITLE
Enable hook tests for windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -194,7 +194,7 @@ jobs:
             distribution: Debian
 
       - run: |
-          cargo test --workspace --test=${{ matrix.test }} --features portable_tests
+          cargo test --workspace --test=${{ matrix.test }} --features portable_tests -- --test-threads=1
 
   test-bin-installable:
     runs-on: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,21 +1304,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,7 +1518,6 @@ dependencies = [
  "notify",
  "num-bigint",
  "open",
- "openssl",
  "os-release",
  "pem",
  "predicates",
@@ -3030,58 +3014,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
-dependencies = [
- "bitflags 2.9.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-src"
-version = "300.5.0+3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.107"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -5035,12 +4971,6 @@ dependencies = [
  "rand 0.9.0",
  "serde",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,6 +1304,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,6 +1533,7 @@ dependencies = [
  "notify",
  "num-bigint",
  "open",
+ "openssl",
  "os-release",
  "pem",
  "predicates",
@@ -3014,10 +3030,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-src"
+version = "300.5.0+3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -4971,6 +5035,12 @@ dependencies = [
  "rand 0.9.0",
  "serde",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -13,8 +13,8 @@ use std::time::{Duration, SystemTime};
 use anyhow::Context;
 use const_format::formatcp;
 use fn_error_context::context;
-use gel_tokio::dsn::CredentialsFile;
 use gel_tokio::InstanceName;
+use gel_tokio::dsn::CredentialsFile;
 use url::Url;
 
 use crate::async_util;
@@ -33,13 +33,13 @@ use crate::portable::instance::control;
 use crate::portable::instance::create;
 use crate::portable::instance::destroy;
 use crate::portable::instance::status;
-use crate::portable::local::{write_json, InstanceInfo, NonLocalInstance, Paths};
+use crate::portable::local::{InstanceInfo, NonLocalInstance, Paths, write_json};
 use crate::portable::options;
 use crate::portable::project;
-use crate::portable::repository::{self, download, PackageHash, PackageInfo};
+use crate::portable::repository::{self, PackageHash, PackageInfo, download};
 use crate::portable::server;
 use crate::portable::ver;
-use crate::print::{self, msg, Highlight};
+use crate::print::{self, Highlight, msg};
 use crate::process;
 
 use super::extension;

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -13,8 +13,8 @@ use std::time::{Duration, SystemTime};
 use anyhow::Context;
 use const_format::formatcp;
 use fn_error_context::context;
-use gel_tokio::InstanceName;
 use gel_tokio::dsn::CredentialsFile;
+use gel_tokio::InstanceName;
 use url::Url;
 
 use crate::async_util;
@@ -33,13 +33,13 @@ use crate::portable::instance::control;
 use crate::portable::instance::create;
 use crate::portable::instance::destroy;
 use crate::portable::instance::status;
-use crate::portable::local::{InstanceInfo, NonLocalInstance, Paths, write_json};
+use crate::portable::local::{write_json, InstanceInfo, NonLocalInstance, Paths};
 use crate::portable::options;
 use crate::portable::project;
-use crate::portable::repository::{self, PackageHash, PackageInfo, download};
+use crate::portable::repository::{self, download, PackageHash, PackageInfo};
 use crate::portable::server;
 use crate::portable::ver;
-use crate::print::{self, Highlight, msg};
+use crate::print::{self, msg, Highlight};
 use crate::process;
 
 use super::extension;
@@ -101,21 +101,6 @@ impl Wsl {
         }
         pro.arg("/usr/bin/edgedb");
         pro.no_proxy();
-        pro
-    }
-    pub fn sh(&self, _current_dir: &Path) -> process::Native {
-        let mut pro = process::Native::new("sh", "sh", "wsl");
-        pro.arg("--user").arg("edgedb");
-        pro.arg("--distribution").arg(&self.distribution);
-        pro.arg("_EDGEDB_FROM_WINDOWS=1");
-        if let Some(log_env) = env::var_os("RUST_LOG") {
-            let mut pair = OsString::with_capacity("RUST_LOG=".len() + log_env.len());
-            pair.push("RUST_LOG=");
-            pair.push(log_env);
-            pro.arg(pair);
-        }
-        // TODO: set current dir
-        pro.arg("/bin/sh");
         pro
     }
     #[cfg(windows)]

--- a/src/watch/scripts.rs
+++ b/src/watch/scripts.rs
@@ -2,7 +2,6 @@ use std::path;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedReceiver;
 
-use crate::portable::windows;
 use crate::print;
 use crate::process;
 
@@ -43,8 +42,9 @@ pub async fn run_script(
     script: &str,
     current_dir: &path::Path,
 ) -> Result<std::process::ExitStatus, anyhow::Error> {
+    let marker = marker.to_string();
+
     let status = if !cfg!(windows) {
-        let marker = marker.to_string();
         process::Native::new("", marker, "/bin/sh")
             .arg("-c")
             .arg(script)
@@ -52,10 +52,10 @@ pub async fn run_script(
             .run_for_status()
             .await?
     } else {
-        let wsl = windows::try_get_wsl()?;
-        wsl.sh(current_dir)
-            .arg("-c")
+        process::Native::new("", marker, "cmd.exe")
+            .arg("/c")
             .arg(script)
+            .current_dir(current_dir)
             .run_for_status()
             .await?
     };

--- a/tests/portable_project.rs
+++ b/tests/portable_project.rs
@@ -239,7 +239,6 @@ fn project_link_and_init() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn hooks() {
     use std::{fs, path};
 


### PR DESCRIPTION
Ok, as I manually verified, hooks and watch mostly work on windows via WSL.

The problem we still face is that when we invoke a command in WSL, it will run within WLS and think it is on Linux. This means it will look at `/root/.config/edgedb` for config instead of `/mnt/c/Users/username/AppData/Roaming/edgedb`.

Which means that `gel instance list` it will return different list of instances within WSL and outside. That breaks the tests we have for hooks (well, a similar thing with project stash).

---

We now need to decide between two options:
- don't run hooks in WSL, but within windows instead. We should think how to execute scripts in this case.
- patch the CLI (and bindings) to understand that they are running on a linux within WSL and use the config from Windows FS instead.