### PR TITLE
Add a secret --installation-path argument to `gel cli install`

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -59,6 +59,9 @@ pub struct Command {
     /// Installation is run from `self upgrade` command
     #[arg(long, hide = true)]
     pub upgrade: bool,
+
+    #[arg(long, hide=true, value_hint=clap::ValueHint::AnyPath)]
+    pub installation_path: Option<PathBuf>,
 }
 
 pub struct Settings {
@@ -114,7 +117,10 @@ fn _run(cmd: &Command) -> anyhow::Result<()> {
             _ => {}
         }
     }
-    let installation_path = binary_path()?.parent().unwrap().to_owned();
+    let installation_path = match &cmd.installation_path {
+        Some(path) => path.clone(),
+        None => binary_path()?.parent().unwrap().to_owned(),
+    };
     let mut settings = Settings {
         rc_files: get_rc_files()?,
         system: false,


### PR DESCRIPTION
We want to start supporting cli upgrade when the CLI is installed in
non-standard locations.

Part of the complication here is that the way this works is that the
old CLI downloads the new CLI and then asks the *new CLI* to install
itself (with the `--upgrade`) flag.

So we need a way to communicate to it where it should do this
installation to `gel cli install`, so we add a hidden
`--installation-path` flag to cli install in order to support this.

(Another approach that I think might work would be to make `gel
install --upgrade` always use the directory of the current
executable. The advantage there is that no new flag needs to be added
that could tangle up the communication, but the disadvantage is that
it is changing existing behavior in possibly dangerous ways.)

My plan is to land this and make sure it is *released on all
channels*, and then I can go update `gel cli upgrade` to use it,
and be able to test it end-to-end as I do so.