### PR TITLE
Allow doing `edgedb cli upgrade` for a CLI anywhere under $HOME

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -114,6 +114,7 @@ fn upgrade(cmd: &Command, path: PathBuf) -> anyhow::Result<()> {
         .arg("cli")
         .arg("install")
         .arg("--upgrade")
+        .arg("--no-modify-path")
         .arg("--installation-path")
         .arg(down_dir)
         .no_proxy()

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -119,11 +119,6 @@ pub fn symlink_dir(original: impl AsRef<Path>, path: impl AsRef<Path>) -> anyhow
     Ok(())
 }
 
-/// The legacy binary path.
-pub fn old_binary_path() -> anyhow::Result<PathBuf> {
-    Ok(home_dir()?.join(".edgedb").join("bin"))
-}
-
 pub fn binary_path() -> anyhow::Result<PathBuf> {
     let dir = match dirs::executable_dir() {
         Some(dir) => dir,


### PR DESCRIPTION
The goal here is to allow doing it from our language-binding-managed
CLI installations.

In order to make this work, we need to pass an `--installation-path`
to the downloaded new CLI version. This was added in #1499, which has
been released on nightly, testing, and stable channels. I tested
upgrading to all of those channels.

A side effect of doing this is that this removes support for migration
from the "old" binary path of `.edgedb/bin/`. That migration happened
in 2021, though, I think, so I'm not super worried.