### PR TITLE
Determine the terminal background color just once, at startup

### DIFF
--- a/src/cli/logo.rs
+++ b/src/cli/logo.rs
@@ -33,7 +33,7 @@ pub fn print_logo(allow_animation: bool, small: bool) {
         .max()
         .unwrap();
 
-    let is_light = terminal_light::luma().map_or(false, |x| x > 0.6);
+    let is_light = print::TERMINAL_LUMA.map_or(false, |x| x > 0.6);
     let primary = if is_light {
         Color::DarkMagenta
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,11 @@ fn _main() -> anyhow::Result<()> {
         }
     }
 
+    // Determine the terminal background color, which will influence
+    // various printing decisions. (We could let it be done lazily,
+    // but I'd rather it be clear when it is run.)
+    print::init_colors();
+
     let opt = Options::from_args_and_env()?;
     opt.conn_options.validate()?;
     let cfg = config::get_config();

--- a/src/print/color.rs
+++ b/src/print/color.rs
@@ -51,12 +51,20 @@ pub trait Highlight: colorful::Colorful + colorful::core::StrMarker + Sized {
 
 impl<T: colorful::Colorful + colorful::core::StrMarker + Sized> Highlight for T {}
 
+pub static TERMINAL_LUMA: once_cell::sync::Lazy<Option<f32>> = once_cell::sync::Lazy::new(|| {
+    if !concolor::get(concolor::Stream::Stdout).color() {
+        return None;
+    }
+
+    terminal_light::luma().ok()
+});
+
 static THEME: once_cell::sync::Lazy<Option<Theme>> = once_cell::sync::Lazy::new(|| {
     if !concolor::get(concolor::Stream::Stdout).color() {
         return None;
     }
 
-    let is_term_light = terminal_light::luma().map_or(false, |x| x > 0.6);
+    let is_term_light = TERMINAL_LUMA.map_or(false, |x| x > 0.6);
 
     Some(if is_term_light {
         Theme {

--- a/src/print/mod.rs
+++ b/src/print/mod.rs
@@ -12,6 +12,7 @@ pub use crate::error_display::print_query_warning as warning;
 pub use crate::error_display::print_query_warnings as warnings;
 pub use crate::msg;
 pub use color::Highlight;
+pub use color::TERMINAL_LUMA;
 
 use std::convert::Infallible;
 use std::error::Error;
@@ -657,6 +658,10 @@ macro_rules! success {
     ($($args:tt)*) => {
         $crate::print::write_success(format_args!($($args)*))
     }
+}
+
+pub fn init_colors() {
+    once_cell::sync::Lazy::force(&TERMINAL_LUMA);
 }
 
 pub use crate::{error, success, warn};


### PR DESCRIPTION
Currently we may determine it twice (once for the logo, once for the
theme), and the theme determining can happen at multiple different
times depending on the code path.

This weirds me out, so I'm changing it.

I was sort of hoping that this would fix the problem where sometimes I
would see the reponse from the terminal make it to my screen instead
of getting captured by the library, and it might have. I haven't see
it with this patch applied.
But I also don't really think it *should* fix it, so, we'll see.