### PR TITLE
Bump gel-tokio to get better TLS warnings and fix security level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,9 +1625,9 @@ dependencies = [
 
 [[package]]
 name = "gel-stream"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7358591cd63ecab3dd9b84297e0b0e78dc611eb90d91db5ab6651d085c426a"
+checksum = "f9ca14a6848cfa27530b123105dd005d45c51a54d1bc0ce6b17294b10b72c8fc"
 dependencies = [
  "derive_more",
  "futures",
@@ -1645,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "gel-tokio"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ead6fc510774a66d06bc656c82bd976c9d84ec1613d372650f866d4365f5ba7"
+checksum = "18f3ff56e8a5b97973a171ad145084e3f859b605f1f5d4743b8eb2f746b406b1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,9 +1625,9 @@ dependencies = [
 
 [[package]]
 name = "gel-stream"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d41a591ba0b08ecb5ec27fd06964a17d680c3ad78607c337d85fd3d54ec6da"
+checksum = "cdda55267c898a9eed8267b384b6f409d1d115e9b517e5a42107e62219e655db"
 dependencies = [
  "derive_more",
  "futures",
@@ -1645,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "gel-tokio"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8481ea5b8bce1530b67aafd5825dfe34999b6796d0095b1e10dc9af55c4b7fbc"
+checksum = "4a25451634765d7e42a3c2cfb01498dd7f453caa22b9996387792d2ba89dd841"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,9 +1625,9 @@ dependencies = [
 
 [[package]]
 name = "gel-stream"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ca14a6848cfa27530b123105dd005d45c51a54d1bc0ce6b17294b10b72c8fc"
+checksum = "c9d41a591ba0b08ecb5ec27fd06964a17d680c3ad78607c337d85fd3d54ec6da"
 dependencies = [
  "derive_more",
  "futures",
@@ -1645,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "gel-tokio"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f3ff56e8a5b97973a171ad145084e3f859b605f1f5d4743b8eb2f746b406b1"
+checksum = "8481ea5b8bce1530b67aafd5825dfe34999b6796d0095b1e10dc9af55c4b7fbc"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/tests/shared-client-tests/build.rs
+++ b/tests/shared-client-tests/build.rs
@@ -118,7 +118,7 @@ static MUTEX: Mutex<()> = Mutex::new(());
     'testcase: for case in connection_testcases.as_array().unwrap() {
         let mut testcase = Vec::new();
         let case = case.as_object().unwrap();
-        let name = case.get("name").unwrap().as_str().unwrap();
+        let name = case.get("name").unwrap().as_str().unwrap().replace(|c:char| !c.is_alphanumeric(), "_");
         let opts = case
             .get("opts")
             .and_then(|v| v.as_object())

--- a/tests/shared-client-tests/build.rs
+++ b/tests/shared-client-tests/build.rs
@@ -118,7 +118,12 @@ static MUTEX: Mutex<()> = Mutex::new(());
     'testcase: for case in connection_testcases.as_array().unwrap() {
         let mut testcase = Vec::new();
         let case = case.as_object().unwrap();
-        let name = case.get("name").unwrap().as_str().unwrap().replace(|c:char| !c.is_alphanumeric(), "_");
+        let name = case
+            .get("name")
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .replace(|c: char| !c.is_alphanumeric(), "_");
         let opts = case
             .get("opts")
             .and_then(|v| v.as_object())


### PR DESCRIPTION
The SSL configuration wasn't properly updating the tlsSecurity -- update gel-stream and gel-tokio to fix this.