### PR TITLE
Usually eliminate ANSI spew on slow ssh connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4232,9 +4232,8 @@ dependencies = [
 
 [[package]]
 name = "terminal-light"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9474484d1a0c031cd7d065c6f027a376859c9fedb32c94df3d7a797218bbb7"
+version = "1.6.0"
+source = "git+https://github.com/msullivan/terminal-light#d077ce4ff1906c5c47b2b438a043a1868bd8c5d4"
 dependencies = [
  "coolor",
  "crossterm",
@@ -5380,8 +5379,7 @@ dependencies = [
 [[package]]
 name = "xterm-query"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775333f1c03ec9f81f7f295de5a8dac7350b91f7e03e2dd730593ba4ec3515d1"
+source = "git+https://github.com/msullivan/xterm-query/#13a7fd895f38bf604ed3e784e7d787fd7b8702b3"
 dependencies = [
  "nix 0.29.0",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ bitflags = "2.6"
 renamore = {version="0.3.2", features = ["always-fallback"]}
 anes = "0.2.0"
 geozero = {version="0.14.0", features=["with-wkb"]}
-terminal-light = "1.7.0"
+terminal-light = {git = "https://github.com/msullivan/terminal-light"}
 globset = "0.4.15"
 x509-parser = "0.17.0"
 

--- a/src/print/color.rs
+++ b/src/print/color.rs
@@ -56,7 +56,7 @@ pub static TERMINAL_LUMA: once_cell::sync::Lazy<Option<f32>> = once_cell::sync::
         return None;
     }
 
-    terminal_light::luma().ok()
+    terminal_light::luma_with_timeout(std::time::Duration::from_millis(5000)).ok()
 });
 
 static THEME: once_cell::sync::Lazy<Option<Theme>> = once_cell::sync::Lazy::new(|| {


### PR DESCRIPTION
At @mmastrac's suggestion, I made the library that queries the
terminal use a "fence" technique where we send a universally-supported
query after the background color query, so that we can detect when the
BG color query isn't handled.

This lets us turn up the timeout quite high (we *maybe* could
eliminate it, but that makes me a little nervous).

I tested on a slow SSH connection using gnome-terminal (which does
support querying BG color) and pterm (which does not).

See:
 * https://github.com/msullivan/xterm-query/pull/1
 * https://github.com/msullivan/terminal-light/pull/1
 * https://github.com/msullivan/terminal-light/pull/2

Fixes #1520.