### PR TITLE
Remove duplicate space

### DIFF
--- a/src/migrations/upgrade_check.rs
+++ b/src/migrations/upgrade_check.rs
@@ -290,7 +290,7 @@ fn print_apply_migration_error() {
     msg!(
         "    {} {}",
         BRANDING_CLI_CMD,
-        " migration create --squash".emphasized()
+        "migration create --squash".emphasized()
     );
 }
 


### PR DESCRIPTION
```
The current schema is compatible, but some of the migrations are outdated.
Please squash all migrations to fix the issue:
    gel  migration create --squash
```