### PR TITLE
Update CLI to use new gel-dsn lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,7 +1436,8 @@ dependencies = [
 [[package]]
 name = "gel-auth"
 version = "0.1.3"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#17f154b5858d140925a030c9b40a331b8aa9e2e5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88768ad83c06b9d2b350b2e62b4000666ffccfe768275b47772dee218af3a8e8"
 dependencies = [
  "base64 0.22.1",
  "constant_time_eq",
@@ -1494,7 +1495,7 @@ dependencies = [
  "fs_extra",
  "futures-util",
  "gel-auth",
- "gel-derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gel-derive",
  "gel-dsn",
  "gel-errors",
  "gel-protocol",
@@ -1593,20 +1594,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gel-derive"
-version = "0.7.0"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#17f154b5858d140925a030c9b40a331b8aa9e2e5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
- "trybuild",
-]
-
-[[package]]
 name = "gel-dsn"
 version = "0.2.0"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#17f154b5858d140925a030c9b40a331b8aa9e2e5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65653315aa82ff89c805cd02276ae511b5929a1f7ffa466aeb9f4c874614240a"
 dependencies = [
  "base64 0.22.1",
  "crc16",
@@ -1631,7 +1622,8 @@ dependencies = [
 [[package]]
 name = "gel-errors"
 version = "0.5.0"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#17f154b5858d140925a030c9b40a331b8aa9e2e5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a34c9305d1e0dd0180d802ce457476dc1dea8a7aeab98bd803ae57e8d84be51"
 dependencies = [
  "bytes",
 ]
@@ -1639,7 +1631,8 @@ dependencies = [
 [[package]]
 name = "gel-protocol"
 version = "0.8.0"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#17f154b5858d140925a030c9b40a331b8aa9e2e5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e85ee2aeaf483be7f4fa95fee42bcfe96dab254456189d14af30ddfe3d0e04b7"
 dependencies = [
  "bigdecimal",
  "bitflags 2.9.0",
@@ -1657,7 +1650,8 @@ dependencies = [
 [[package]]
 name = "gel-stream"
 version = "0.2.1"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#17f154b5858d140925a030c9b40a331b8aa9e2e5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcc911cb4181fd08fbb408de3d07beb41ade357da220da8c72ffc32c5a05295"
 dependencies = [
  "derive_more",
  "futures",
@@ -1677,7 +1671,8 @@ dependencies = [
 [[package]]
 name = "gel-tokio"
 version = "0.10.1"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#17f154b5858d140925a030c9b40a331b8aa9e2e5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3674b3bb31b7f5327e81a4d77352cbe158cb9489e126aa3ef8cb44e94e9174ea"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1689,7 +1684,7 @@ dependencies = [
  "dirs",
  "futures-util",
  "gel-auth",
- "gel-derive 0.7.0 (git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak)",
+ "gel-derive",
  "gel-dsn",
  "gel-errors",
  "gel-protocol",
@@ -1977,13 +1972,13 @@ dependencies = [
 
 [[package]]
 name = "hostname"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
 dependencies = [
+ "cfg-if",
  "libc",
- "match_cfg",
- "winapi",
+ "windows",
 ]
 
 [[package]]
@@ -2660,12 +2655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
-
-[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3276,12 +3265,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quinn"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3582,12 +3565,11 @@ dependencies = [
 
 [[package]]
 name = "resolv-conf"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
+checksum = "48375394603e3dd4b2d64371f7148fd8c7baa2680e28741f2cb8d23b59e3d4c4"
 dependencies = [
  "hostname",
- "quick-error",
 ]
 
 [[package]]
@@ -4476,9 +4458,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.0"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4536,9 +4518,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5076,6 +5058,25 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,26 +1436,7 @@ dependencies = [
 [[package]]
 name = "gel-auth"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88768ad83c06b9d2b350b2e62b4000666ffccfe768275b47772dee218af3a8e8"
-dependencies = [
- "base64 0.22.1",
- "constant_time_eq",
- "derive_more",
- "hmac",
- "md5",
- "rand 0.8.5",
- "roaring",
- "sha2",
- "thiserror 2.0.12",
- "tracing",
- "unicode-normalization",
-]
-
-[[package]]
-name = "gel-auth"
-version = "0.1.3"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#25ffc8a5b85b68f101a810dc30df79a48e444f03"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#17f154b5858d140925a030c9b40a331b8aa9e2e5"
 dependencies = [
  "base64 0.22.1",
  "constant_time_eq",
@@ -1512,7 +1493,7 @@ dependencies = [
  "fs-err",
  "fs_extra",
  "futures-util",
- "gel-auth 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gel-auth",
  "gel-derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gel-dsn",
  "gel-errors",
@@ -1614,7 +1595,7 @@ dependencies = [
 [[package]]
 name = "gel-derive"
 version = "0.7.0"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#25ffc8a5b85b68f101a810dc30df79a48e444f03"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#17f154b5858d140925a030c9b40a331b8aa9e2e5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1625,13 +1606,13 @@ dependencies = [
 [[package]]
 name = "gel-dsn"
 version = "0.2.0"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#25ffc8a5b85b68f101a810dc30df79a48e444f03"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#17f154b5858d140925a030c9b40a331b8aa9e2e5"
 dependencies = [
  "base64 0.22.1",
  "crc16",
  "derive_more",
  "dirs",
- "gel-auth 0.1.3 (git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak)",
+ "gel-auth",
  "gel-errors",
  "gel-stream",
  "log",
@@ -1650,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "gel-errors"
 version = "0.5.0"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#25ffc8a5b85b68f101a810dc30df79a48e444f03"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#17f154b5858d140925a030c9b40a331b8aa9e2e5"
 dependencies = [
  "bytes",
 ]
@@ -1658,7 +1639,7 @@ dependencies = [
 [[package]]
 name = "gel-protocol"
 version = "0.8.0"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#25ffc8a5b85b68f101a810dc30df79a48e444f03"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#17f154b5858d140925a030c9b40a331b8aa9e2e5"
 dependencies = [
  "bigdecimal",
  "bitflags 2.9.0",
@@ -1676,7 +1657,7 @@ dependencies = [
 [[package]]
 name = "gel-stream"
 version = "0.2.1"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#25ffc8a5b85b68f101a810dc30df79a48e444f03"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#17f154b5858d140925a030c9b40a331b8aa9e2e5"
 dependencies = [
  "derive_more",
  "futures",
@@ -1695,8 +1676,8 @@ dependencies = [
 
 [[package]]
 name = "gel-tokio"
-version = "0.10.0"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#25ffc8a5b85b68f101a810dc30df79a48e444f03"
+version = "0.10.1"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#17f154b5858d140925a030c9b40a331b8aa9e2e5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1707,7 +1688,7 @@ dependencies = [
  "crc16",
  "dirs",
  "futures-util",
- "gel-auth 0.1.3 (git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak)",
+ "gel-auth",
  "gel-derive 0.7.0 (git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak)",
  "gel-dsn",
  "gel-errors",
@@ -2075,9 +2056,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "humantime-serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,7 +1455,7 @@ dependencies = [
 [[package]]
 name = "gel-auth"
 version = "0.1.3"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#e4dd653082649689ea392d1f2f38143253f7b4d6"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#25ffc8a5b85b68f101a810dc30df79a48e444f03"
 dependencies = [
  "base64 0.22.1",
  "constant_time_eq",
@@ -1614,7 +1614,7 @@ dependencies = [
 [[package]]
 name = "gel-derive"
 version = "0.7.0"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#e4dd653082649689ea392d1f2f38143253f7b4d6"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#25ffc8a5b85b68f101a810dc30df79a48e444f03"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1625,7 +1625,7 @@ dependencies = [
 [[package]]
 name = "gel-dsn"
 version = "0.2.0"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#e4dd653082649689ea392d1f2f38143253f7b4d6"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#25ffc8a5b85b68f101a810dc30df79a48e444f03"
 dependencies = [
  "base64 0.22.1",
  "crc16",
@@ -1650,7 +1650,7 @@ dependencies = [
 [[package]]
 name = "gel-errors"
 version = "0.5.0"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#e4dd653082649689ea392d1f2f38143253f7b4d6"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#25ffc8a5b85b68f101a810dc30df79a48e444f03"
 dependencies = [
  "bytes",
 ]
@@ -1658,7 +1658,7 @@ dependencies = [
 [[package]]
 name = "gel-protocol"
 version = "0.8.0"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#e4dd653082649689ea392d1f2f38143253f7b4d6"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#25ffc8a5b85b68f101a810dc30df79a48e444f03"
 dependencies = [
  "bigdecimal",
  "bitflags 2.9.0",
@@ -1676,7 +1676,7 @@ dependencies = [
 [[package]]
 name = "gel-stream"
 version = "0.2.1"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#e4dd653082649689ea392d1f2f38143253f7b4d6"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#25ffc8a5b85b68f101a810dc30df79a48e444f03"
 dependencies = [
  "derive_more",
  "futures",
@@ -1696,7 +1696,7 @@ dependencies = [
 [[package]]
 name = "gel-tokio"
 version = "0.10.0"
-source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#e4dd653082649689ea392d1f2f38143253f7b4d6"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#25ffc8a5b85b68f101a810dc30df79a48e444f03"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "append-only-vec"
@@ -198,7 +198,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
 ]
 
@@ -210,7 +210,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -222,7 +222,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.18"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+checksum = "310c9bcae737a48ef5cdee3174184e6d548b292739ede61a1f955ef76a738861"
 dependencies = [
  "brotli",
  "flate2",
@@ -267,13 +267,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -349,9 +349,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bitvec"
@@ -378,16 +378,15 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1230237285e3e10cde447185e8975408ae24deaa67205ce684805c25bc0c7937"
+checksum = "675f87afced0413c9bb02843499dbbd3882a237645883f71a2b59644a6d2f753"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "memmap2",
 ]
 
 [[package]]
@@ -439,9 +438,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "byteorder"
@@ -451,36 +450,34 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bzip2"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
 dependencies = [
  "bzip2-sys",
- "libc",
 ]
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.12+1.0.8"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ebc2f1a417f01e1da30ef264ee86ae31d2dcd2d603ea283d3c244a883ca2a9"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.15"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -513,9 +510,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "num-traits",
 ]
@@ -532,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -542,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -564,14 +561,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -617,7 +614,7 @@ dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -680,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -887,11 +884,11 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "crossterm_winapi",
  "mio",
  "parking_lot 0.12.3",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -975,7 +972,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -996,7 +993,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "unicode-xid",
 ]
 
@@ -1073,14 +1070,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "dissimilar"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f8e79d1fbf76bdfbde321e902714bf6c49df88a7dda6fc682fc2979226962d"
+checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
 
 [[package]]
 name = "doc-comment"
@@ -1096,19 +1093,18 @@ checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "dtor"
-version = "0.0.2"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb62086e769dab0cfd38c939e953f557f3a93c92c77131a45f5cb658bc3f579"
+checksum = "222ef136a1c687d4aa0395c175f2c4586e379924c352fd02f7870cf7de783c23"
 dependencies = [
  "dtor-proc-macro",
- "libc-print",
 ]
 
 [[package]]
 name = "dtor-proc-macro"
-version = "0.0.2"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99dc540397d4824b3541f3cb4ed40ff569df8f7d9ac797684ba5aa3633583f37"
+checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "edgedb-cli-derive"
@@ -1120,7 +1116,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "termimad",
  "trybuild",
 ]
@@ -1141,15 +1137,15 @@ dependencies = [
  "serde_json",
  "sha2",
  "snafu",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "unicode-width 0.1.14",
 ]
 
 [[package]]
 name = "either"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -1181,7 +1177,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1196,14 +1192,14 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
 dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "humantime",
+ "jiff",
  "log",
 ]
 
@@ -1237,13 +1233,13 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fd-lock"
-version = "4.0.2"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
- "rustix",
- "windows-sys 0.52.0",
+ "rustix 1.0.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1285,7 +1281,7 @@ checksum = "2cd66269887534af4b0c3e3337404591daa8dc8b9b2b3db71f9523beb4bafb41"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1404,7 +1400,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1451,7 +1447,25 @@ dependencies = [
  "rand 0.8.5",
  "roaring",
  "sha2",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
+ "tracing",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gel-auth"
+version = "0.1.3"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#e4dd653082649689ea392d1f2f38143253f7b4d6"
+dependencies = [
+ "base64 0.22.1",
+ "constant_time_eq",
+ "derive_more",
+ "hmac",
+ "md5",
+ "rand 0.8.5",
+ "roaring",
+ "sha2",
+ "thiserror 2.0.12",
  "tracing",
  "unicode-normalization",
 ]
@@ -1470,7 +1484,7 @@ dependencies = [
  "base32",
  "base64 0.22.1",
  "bigdecimal",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "bitvec",
  "blake2b_simd",
  "blake3",
@@ -1498,8 +1512,9 @@ dependencies = [
  "fs-err",
  "fs_extra",
  "futures-util",
- "gel-auth",
- "gel-derive",
+ "gel-auth 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gel-derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gel-dsn",
  "gel-errors",
  "gel-protocol",
  "gel-tokio",
@@ -1562,7 +1577,7 @@ dependencies = [
  "test-case",
  "test-utils",
  "textwrap",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "toml",
@@ -1592,15 +1607,50 @@ checksum = "39c136cc723c84c27f1c294c9ecb3fbd59287b7845b02c8c3c264d7a43653cd6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "trybuild",
+]
+
+[[package]]
+name = "gel-derive"
+version = "0.7.0"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#e4dd653082649689ea392d1f2f38143253f7b4d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "trybuild",
+]
+
+[[package]]
+name = "gel-dsn"
+version = "0.2.0"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#e4dd653082649689ea392d1f2f38143253f7b4d6"
+dependencies = [
+ "base64 0.22.1",
+ "crc16",
+ "derive_more",
+ "dirs",
+ "gel-auth 0.1.3 (git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak)",
+ "gel-errors",
+ "gel-stream",
+ "log",
+ "paste",
+ "percent-encoding",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "sha1",
+ "thiserror 2.0.12",
+ "url",
+ "whoami",
 ]
 
 [[package]]
 name = "gel-errors"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a34c9305d1e0dd0180d802ce457476dc1dea8a7aeab98bd803ae57e8d84be51"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#e4dd653082649689ea392d1f2f38143253f7b4d6"
 dependencies = [
  "bytes",
 ]
@@ -1608,11 +1658,10 @@ dependencies = [
 [[package]]
 name = "gel-protocol"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85ee2aeaf483be7f4fa95fee42bcfe96dab254456189d14af30ddfe3d0e04b7"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#e4dd653082649689ea392d1f2f38143253f7b4d6"
 dependencies = [
  "bigdecimal",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "bytes",
  "chrono",
  "gel-errors",
@@ -1626,9 +1675,8 @@ dependencies = [
 
 [[package]]
 name = "gel-stream"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdda55267c898a9eed8267b384b6f409d1d115e9b517e5a42107e62219e655db"
+version = "0.2.1"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#e4dd653082649689ea392d1f2f38143253f7b4d6"
 dependencies = [
  "derive_more",
  "futures",
@@ -1637,8 +1685,9 @@ dependencies = [
  "rustls-pki-types",
  "rustls-platform-verifier",
  "rustls-tokio-stream",
+ "serde",
  "socket2",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "webpki",
  "webpki-roots",
@@ -1646,9 +1695,8 @@ dependencies = [
 
 [[package]]
 name = "gel-tokio"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a25451634765d7e42a3c2cfb01498dd7f453caa22b9996387792d2ba89dd841"
+version = "0.10.0"
+source = "git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak#e4dd653082649689ea392d1f2f38143253f7b4d6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1659,8 +1707,9 @@ dependencies = [
  "crc16",
  "dirs",
  "futures-util",
- "gel-auth",
- "gel-derive",
+ "gel-auth 0.1.3 (git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak)",
+ "gel-derive 0.7.0 (git+https://github.com/mmastrac/edgedb-rust.git?branch=unix_path_tweak)",
+ "gel-dsn",
  "gel-errors",
  "gel-protocol",
  "gel-stream",
@@ -1705,7 +1754,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1729,7 +1778,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc3655aa6818d65bc620d6911f05aa7b6aeb596291e1e9f79e52df85583d1e30"
 dependencies = [
- "rustix",
+ "rustix 0.38.44",
  "windows-targets 0.52.6",
 ]
 
@@ -1772,9 +1821,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "globset"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1813,7 +1862,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
+ "http 1.3.1",
  "indexmap",
  "slab",
  "tokio",
@@ -1869,9 +1918,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
 name = "hex"
@@ -1969,9 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -1996,27 +2045,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.2.0",
+ "futures-core",
+ "http 1.3.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -2074,7 +2123,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2 0.4.8",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
  "itoa",
@@ -2091,14 +2140,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
  "rustls 0.23.23",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.2",
  "tower-service",
 ]
 
@@ -2111,7 +2160,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
  "pin-project-lite",
@@ -2236,7 +2285,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2271,9 +2320,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -2299,7 +2348,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "inotify-sys",
  "libc",
 ]
@@ -2363,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -2390,9 +2439,33 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "jni"
@@ -2475,7 +2548,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2486,9 +2559,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libc-print"
@@ -2535,9 +2608,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "libc",
- "redox_syscall 0.5.9",
+ "redox_syscall 0.5.10",
 ]
 
 [[package]]
@@ -2553,10 +2626,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
-name = "litemap"
-version = "0.7.4"
+name = "linux-raw-sys"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+
+[[package]]
+name = "litemap"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -2616,15 +2695,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memmap2"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "memoffset"
@@ -2721,7 +2791,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "libc",
 ]
@@ -2732,7 +2802,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -2744,7 +2814,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -2772,7 +2842,7 @@ version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "filetime",
  "fsevent-sys",
  "inotify",
@@ -2853,9 +2923,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
 
 [[package]]
 name = "open"
@@ -2874,7 +2944,7 @@ version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2891,7 +2961,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2980,10 +3050,16 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.9",
+ "redox_syscall 0.5.10",
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -3047,7 +3123,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3061,22 +3137,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3093,15 +3169,24 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -3111,11 +3196,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -3202,9 +3287,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -3228,7 +3313,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.23",
  "socket2",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -3247,7 +3332,7 @@ dependencies = [
  "rustls 0.23.23",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3269,9 +3354,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -3310,8 +3395,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.2",
- "zerocopy 0.8.20",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -3331,7 +3416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.2",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3345,12 +3430,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a509b1a2ffbe92afab0e55c8fd99dea1c280e8171bd2d88682bb20bc41cbc2c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.1",
- "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -3364,11 +3448,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -3390,7 +3474,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -3434,9 +3518,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
@@ -3445,7 +3529,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.8",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
@@ -3468,7 +3552,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.2",
  "tokio-util",
  "tower",
  "tower-service",
@@ -3487,7 +3571,7 @@ checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 1.2.0",
+ "http 1.3.1",
  "reqwest",
  "serde",
  "thiserror 1.0.69",
@@ -3504,7 +3588,7 @@ dependencies = [
  "async-trait",
  "futures",
  "getrandom 0.2.15",
- "http 1.2.0",
+ "http 1.3.1",
  "hyper 1.6.0",
  "parking_lot 0.11.2",
  "reqwest",
@@ -3548,9 +3632,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.11"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
@@ -3624,10 +3708,23 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.2",
  "windows-sys 0.59.0",
 ]
 
@@ -3742,9 +3839,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "rustyline"
@@ -3752,7 +3849,7 @@ version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
@@ -3770,9 +3867,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -3816,7 +3913,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3835,38 +3932,38 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3886,9 +3983,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
  "serde",
@@ -4051,7 +4148,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4101,9 +4198,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4127,7 +4224,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4155,15 +4252,15 @@ checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
 dependencies = [
  "cfg-if",
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 1.0.2",
  "windows-sys 0.59.0",
 ]
 
@@ -4226,11 +4323,11 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
+checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix",
+ "rustix 1.0.2",
  "windows-sys 0.59.0",
 ]
 
@@ -4258,7 +4355,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4269,7 +4366,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "test-case-core",
 ]
 
@@ -4291,13 +4388,13 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -4311,11 +4408,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -4326,25 +4423,25 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
 dependencies = [
  "deranged",
  "itoa",
@@ -4357,15 +4454,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4383,9 +4480,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4398,9 +4495,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4421,7 +4518,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4437,9 +4534,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls 0.23.23",
  "tokio",
@@ -4550,7 +4647,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4570,9 +4667,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b812699e0c4f813b872b373a4471717d9eb550da14b311058a4d9cf4173cbca6"
+checksum = "6ae08be68c056db96f0e6c6dd820727cca756ced9e1f4cc7fdd20e2a55e23898"
 dependencies = [
  "glob",
  "serde",
@@ -4597,9 +4694,9 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-linebreak"
@@ -4684,9 +4781,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d59ca99a559661b96bf898d8fce28ed87935fd2bea9f05983c1464dd6c71b1"
+checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
 dependencies = [
  "getrandom 0.3.1",
  "rand 0.9.0",
@@ -4805,7 +4902,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -4840,7 +4937,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4947,7 +5044,7 @@ checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
 dependencies = [
  "either",
  "home",
- "rustix",
+ "rustix 0.38.44",
  "winsafe",
 ]
 
@@ -4957,7 +5054,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
 dependencies = [
- "redox_syscall 0.5.9",
+ "redox_syscall 0.5.10",
  "wasite",
  "web-sys",
 ]
@@ -5000,33 +5097,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-link"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -5104,11 +5206,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -5130,6 +5248,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5146,6 +5270,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5166,10 +5296,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5190,6 +5332,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5206,6 +5354,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5226,6 +5380,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5244,10 +5404,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.3"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]
@@ -5284,7 +5450,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -5344,19 +5510,18 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
 ]
 
 [[package]]
 name = "xattr"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909"
+checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "linux-raw-sys",
- "rustix",
+ "rustix 1.0.2",
 ]
 
 [[package]]
@@ -5394,7 +5559,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -5404,17 +5569,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
  "zerocopy-derive 0.7.35",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.20"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde3bb8c68a8f3f1ed4ac9221aad6b10cece3e60a8e2ea54a6a2dec806d0084c"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
 dependencies = [
- "zerocopy-derive 0.8.20",
+ "zerocopy-derive 0.8.23",
 ]
 
 [[package]]
@@ -5425,38 +5589,38 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.20"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -5477,7 +5641,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5499,14 +5663,14 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "zip"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
+checksum = "b280484c454e74e5fff658bbf7df8fdbe7a07c6b2de4a53def232c15ef138f3a"
 dependencies = [
  "aes",
  "arbitrary",
@@ -5524,7 +5688,7 @@ dependencies = [
  "pbkdf2",
  "rand 0.8.5",
  "sha1",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
  "zeroize",
  "zopfli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,11 +199,3 @@ vec_init_then_push = 'allow'
 while_let_on_iterator = 'allow'
 too_many_arguments = 'allow'
 clone_on_copy = 'allow'
-
-[patch.crates-io]
-gel-dsn = { git = "https://github.com/mmastrac/edgedb-rust.git", branch = "unix_path_tweak" }
-gel-stream = { git = "https://github.com/mmastrac/edgedb-rust.git", branch = "unix_path_tweak" }
-gel-errors = { git = "https://github.com/mmastrac/edgedb-rust.git", branch = "unix_path_tweak" }
-gel-tokio = { git = "https://github.com/mmastrac/edgedb-rust.git", branch = "unix_path_tweak" }
-gel-protocol = { git = "https://github.com/mmastrac/edgedb-rust.git", branch = "unix_path_tweak" }
-gel-auth = { git = "https://github.com/mmastrac/edgedb-rust.git", branch = "unix_path_tweak" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,3 +206,4 @@ gel-stream = { git = "https://github.com/mmastrac/edgedb-rust.git", branch = "un
 gel-errors = { git = "https://github.com/mmastrac/edgedb-rust.git", branch = "unix_path_tweak" }
 gel-tokio = { git = "https://github.com/mmastrac/edgedb-rust.git", branch = "unix_path_tweak" }
 gel-protocol = { git = "https://github.com/mmastrac/edgedb-rust.git", branch = "unix_path_tweak" }
+gel-auth = { git = "https://github.com/mmastrac/edgedb-rust.git", branch = "unix_path_tweak" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,9 @@ edgeql-parser = {git = "https://github.com/edgedb/edgeql"}
 gel-protocol = { version = "0.8", features = ["all-types"] }
 gel-derive = { version = "0.7" }
 gel-errors = { version = "0.5" }
-gel-tokio = { version = "0.9", features=["admin_socket", "unstable"] }
 gel-auth = { version = "0.1" }
+gel-tokio = { version = "0.10", features=["admin_socket", "unstable"] }
+gel-dsn = { version = "0.2", features = ["unstable", "gel", "auto-log-trace", "auto-log-warning"] }
 
 snafu = "0.8.4"
 ansi-escapes = "0.2"
@@ -198,3 +199,10 @@ vec_init_then_push = 'allow'
 while_let_on_iterator = 'allow'
 too_many_arguments = 'allow'
 clone_on_copy = 'allow'
+
+[patch.crates-io]
+gel-dsn = { git = "https://github.com/mmastrac/edgedb-rust.git", branch = "unix_path_tweak" }
+gel-stream = { git = "https://github.com/mmastrac/edgedb-rust.git", branch = "unix_path_tweak" }
+gel-errors = { git = "https://github.com/mmastrac/edgedb-rust.git", branch = "unix_path_tweak" }
+gel-tokio = { git = "https://github.com/mmastrac/edgedb-rust.git", branch = "unix_path_tweak" }
+gel-protocol = { git = "https://github.com/mmastrac/edgedb-rust.git", branch = "unix_path_tweak" }

--- a/src/branch/context.rs
+++ b/src/branch/context.rs
@@ -1,11 +1,9 @@
-use gel_tokio::get_stash_path;
-
 use crate::branding::BRANDING_CLOUD;
 use crate::connect::Connection;
 use crate::credentials;
 use crate::platform::tmp_file_path;
 use crate::portable::options::InstanceName;
-use crate::portable::project;
+use crate::portable::project::{self, get_stash_path};
 use std::fs;
 use std::sync::Mutex;
 
@@ -71,8 +69,8 @@ impl Context {
 
         // if the instance is unknown, current branch is just "the branch of the connection"
         // so we can pull it out here (if it is not the default branch)
-        if connection.branch() != "__default__" {
-            return Ok(connection.branch().to_string());
+        if let Some(name) = connection.database().name() {
+            return Ok(name.to_string());
         }
 
         // if the connection branch is the default branch, query the database to see

--- a/src/branch/rename.rs
+++ b/src/branch/rename.rs
@@ -13,7 +13,9 @@ pub async fn run(
 ) -> anyhow::Result<branch::CommandResult> {
     let current_branch = context.get_current_branch(connection).await?;
 
-    if options.old_name == current_branch || connection.database() == options.old_name {
+    if options.old_name == current_branch
+        || connection.database().branch().unwrap_or_default() == options.old_name
+    {
         let mut modify_connection =
             get_connection_to_modify(&options.old_name, cli_opts, connection).await?;
         rename(&mut modify_connection.connection, options).await?;
@@ -28,7 +30,7 @@ pub async fn run(
         options.old_name, options.new_name
     );
 
-    if connection.database() == options.old_name {
+    if connection.database().branch().unwrap_or_default() == options.old_name {
         return Ok(branch::CommandResult {
             new_branch: Some(options.new_name.clone()),
         });

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -10,7 +10,6 @@ use std::process::exit;
 
 use anyhow::Context;
 use const_format::concatcp;
-use gel_tokio::get_stash_path;
 use prettytable::{Cell, Row, Table};
 
 use crate::branding::BRANDING_CLI_CMD_ALT_FILE;
@@ -22,6 +21,7 @@ use crate::commands::ExitCode;
 use crate::platform::{binary_path, config_dir, current_exe, home_dir};
 use crate::portable::platform;
 use crate::portable::project;
+use crate::portable::project::get_stash_path;
 use crate::print::{self, msg};
 use crate::print_markdown;
 use crate::process;

--- a/src/cloud/client.rs
+++ b/src/cloud/client.rs
@@ -10,6 +10,7 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 
 use anyhow::Context;
+use log::warn;
 use reqwest::{header, StatusCode};
 
 use crate::branding::BRANDING_CLI_CMD;
@@ -84,13 +85,14 @@ impl CloudClient {
         let profile = if let Some(p) = options_profile.clone() {
             Some(p)
         } else {
-            gel_tokio::env::Env::cloud_profile()?
+            Env::cloud_profile()?
         };
         let secret_key = if let Some(secret_key) = options_secret_key {
             Some(secret_key.into())
         } else if let Some(secret_key) = Env::cloud_secret_key()? {
+            warn!("Using deprecated cloud secret key from environment variable: Use GEL_SECRET_KEY instead");
             Some(secret_key)
-        } else if let Some(secret_key) = gel_tokio::env::Env::secret_key()? {
+        } else if let Some(secret_key) = Env::secret_key()? {
             Some(secret_key)
         } else {
             match fs::read_to_string(cloud_config_file(&profile)?) {
@@ -164,9 +166,9 @@ impl CloudClient {
         };
 
         let api_endpoint = reqwest::Url::parse(&api_endpoint)?;
-        if let Some(cloud_certs) = gel_tokio::env::Env::_cloud_certs()? {
+        if let Some(cloud_certs) = Env::cloud_certs()? {
             log::info!("Using cloud certs for {cloud_certs:?}");
-            let root = cloud_certs.root();
+            let root = cloud_certs.certificates_pem();
             log::trace!("{root}");
             // Add all certificates from the PEM bundle to the root store
             builder = builder

--- a/src/commands/backslash.rs
+++ b/src/commands/backslash.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 
 use clap::{CommandFactory, FromArgMatches};
 use const_format::concatcp;
+use gel_dsn::gel::DatabaseBranch;
 use once_cell::sync::Lazy;
 use prettytable::{Cell, Row, Table};
 use regex::Regex;
@@ -596,7 +597,7 @@ pub async fn execute(
             let result = execute::common(Some(conn), cmd, &options).await?;
 
             if let Some(branch) = result.new_branch {
-                prompt.try_connect(&branch).await?;
+                prompt.try_connect(DatabaseBranch::Branch(branch)).await?;
             }
 
             Ok(Skip)
@@ -674,7 +675,7 @@ pub async fn execute(
                 print::warn!("WARNING: Transaction canceled.");
             }
             prompt
-                .try_connect(&c.database_name)
+                .try_connect(DatabaseBranch::Ambiguous(c.database_name.clone()))
                 .await
                 .map_err(|e| {
                     print::error!("Cannot connect: {e:#}");

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -138,7 +138,7 @@ pub fn main(options: Options, cfg: Config) -> Result<(), anyhow::Error> {
         input_mode: cfg.shell.input_mode.unwrap_or(repl::InputMode::Emacs),
         print_stats: cfg.shell.print_stats.unwrap_or(repl::PrintStats::Off),
         history_limit: cfg.shell.history_size.unwrap_or(10000),
-        branch: conn_config.database().into(),
+        branch: conn_config.db.clone(),
         conn_params: conn,
         last_version: None,
         connection: None,

--- a/src/migrations/upgrade_check.rs
+++ b/src/migrations/upgrade_check.rs
@@ -175,13 +175,12 @@ async fn do_check(ctx: &Context, status_file: &Path, watch: bool) -> anyhow::Res
     } else {
         Path::new(&status.tls_cert_file).to_path_buf()
     };
-    let cert_data = fs::read_to_string(&cert_path)
-        .await
-        .with_context(|| format!("cannot read cert file {cert_path:?}"))?;
     let config = Builder::new()
-        .port(status.port)?
-        .pem_certificates(&cert_data)?
-        .constrained_build()
+        .port(status.port)
+        .tls_ca_file(&cert_path)
+        .without_system()
+        .with_fs()
+        .build()
         .context("cannot build connection params")?;
     let cli = &mut Connection::connect(&config, QUERY_TAG).await?;
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -942,13 +942,13 @@ pub fn prepare_conn_params(opts: &Options) -> anyhow::Result<Builder> {
             anyhow::bail!("`--admin` requires `--unix-path` or `--instance`");
         }
         if let Some(unix_path) = &tmp.unix_path {
-            bld = bld.unix_path(unix_path.to_path_buf());
+            bld = bld.unix_path(UnixPath::PortSuffixed(unix_path.join(".s.EDGEDB.admin.")));
         }
         if let Some(instance) = &tmp.instance {
             let InstanceName::Local(name) = &instance else {
                 anyhow::bail!("`--instance` must be a local instance name when using `--admin`");
             };
-            let sock = runstate_dir(name)?.join(".EDGEDB.admin.");
+            let sock = runstate_dir(name)?.join(".s.EDGEDB.admin.");
             bld = bld.unix_path(UnixPath::PortSuffixed(sock));
         }
     }

--- a/src/options.rs
+++ b/src/options.rs
@@ -942,14 +942,16 @@ pub fn prepare_conn_params(opts: &Options) -> anyhow::Result<Builder> {
             anyhow::bail!("`--admin` requires `--unix-path` or `--instance`");
         }
         if let Some(unix_path) = &tmp.unix_path {
-            bld = bld.unix_path(UnixPath::PortSuffixed(unix_path.join(".s.EDGEDB.admin.")));
+            bld = bld.unix_path(UnixPath::with_port_suffix(
+                unix_path.join(".s.EDGEDB.admin."),
+            ));
         }
         if let Some(instance) = &tmp.instance {
             let InstanceName::Local(name) = &instance else {
                 anyhow::bail!("`--instance` must be a local instance name when using `--admin`");
             };
             let sock = runstate_dir(name)?.join(".s.EDGEDB.admin.");
-            bld = bld.unix_path(UnixPath::PortSuffixed(sock));
+            bld = bld.unix_path(UnixPath::with_port_suffix(sock));
         }
     }
     if let Some(host) = &tmp.host {

--- a/src/portable/instance/create.rs
+++ b/src/portable/instance/create.rs
@@ -588,7 +588,7 @@ pub fn bootstrap(
         .with_context(|| format!("renaming {:?} -> {:?}", tmp_data, paths.data_dir))?;
 
     let mut creds = Credentials::default();
-    creds.port = info.port;
+    creds.port = Some(info.port);
     creds.user = user.into();
     creds.database = Some(database.to_string());
     creds.password = Some(password);

--- a/src/portable/instance/reset_password.rs
+++ b/src/portable/instance/reset_password.rs
@@ -115,8 +115,8 @@ pub fn run(options: &Command) -> anyhow::Result<()> {
         .enable_all()
         .build()?
         .block_on(async {
-            let conn_params = inst.admin_conn_params()?.constrained_build()?;
-            let mut cli = Connection::connect(&conn_params, QUERY_TAG).await?;
+            let config = inst.admin_conn_params()?;
+            let mut cli = Connection::connect(&config, QUERY_TAG).await?;
             cli.execute(
                 &format!(
                     r###"

--- a/src/portable/instance/upgrade.rs
+++ b/src/portable/instance/upgrade.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 use anyhow::Context;
 use const_format::concatcp;
@@ -481,8 +481,7 @@ pub async fn dump_instance(inst: &InstanceInfo, destination: &Path) -> anyhow::R
         log::info!("Removing old dump at {}", destination.display());
         fs::remove_dir_all(&destination).await?;
     }
-    let conn_params = inst.admin_conn_params()?;
-    let config = conn_params.build_env().await?;
+    let config = inst.admin_conn_params()?;
     let mut cli = Connection::connect(&config, QUERY_TAG).await?;
     let options = commands::Options {
         command_line: true,
@@ -568,11 +567,8 @@ fn reinit_and_restore(inst: &InstanceInfo, paths: &Paths) -> anyhow::Result<()> 
 
 async fn restore_instance(inst: &InstanceInfo, path: &Path) -> anyhow::Result<()> {
     use crate::commands::parser::Restore;
-    let mut conn_params = inst.admin_conn_params()?;
-    conn_params.wait_until_available(Duration::from_secs(300));
-
     log::info!("Restoring instance {:?}", inst.name);
-    let cfg = conn_params.build_env().await?;
+    let cfg = inst.admin_conn_params()?;
     let mut cli = Connection::connect(&cfg, QUERY_TAG).await?;
 
     let options = commands::Options {

--- a/src/portable/local.rs
+++ b/src/portable/local.rs
@@ -10,7 +10,7 @@ use std::time::SystemTime;
 use anyhow::Context;
 use fn_error_context::context;
 
-use gel_tokio::Builder;
+use gel_tokio::{Builder, Config};
 
 use crate::branding::BRANDING;
 use crate::bug;
@@ -375,14 +375,14 @@ impl InstanceInfo {
         self.get_installation()?.extension_loader_path()
     }
 
-    pub fn admin_conn_params(&self) -> anyhow::Result<Builder> {
-        let mut builder = Builder::new();
-        builder.port(self.port)?;
-        builder.unix_path(&runstate_dir(&self.name)?);
-        builder.admin(true);
-        builder.user("edgedb")?;
-        builder.database("edgedb")?;
-        Ok(builder)
+    pub fn admin_conn_params(&self) -> anyhow::Result<Config> {
+        let config = Builder::new()
+            .port(self.port)
+            .unix_path(&runstate_dir(&self.name)?)
+            .wait_until_available(std::time::Duration::from_secs(300))
+            .without_system()
+            .build()?;
+        Ok(config)
     }
 }
 
@@ -436,90 +436,6 @@ impl InstallInfo {
             )
         }
     }
-}
-
-pub fn is_valid_local_instance_name(name: &str) -> bool {
-    // For local instance names:
-    //  1. Allow only letters, numbers, underscores and single dashes
-    //  2. Must not start or end with a dash
-    // regex: ^[a-zA-Z_0-9]+(-[a-zA-Z_0-9]+)*$
-    let mut chars = name.chars();
-    match chars.next() {
-        Some(c) if c.is_ascii_alphanumeric() || c == '_' => {}
-        _ => return false,
-    }
-    let mut was_dash = false;
-    for c in chars {
-        if c == '-' {
-            if was_dash {
-                return false;
-            } else {
-                was_dash = true;
-            }
-        } else {
-            if !c.is_ascii_alphanumeric() && c != '_' {
-                return false;
-            }
-            was_dash = false;
-        }
-    }
-    !was_dash
-}
-
-pub fn is_valid_cloud_instance_name(name: &str) -> bool {
-    // For cloud instance name part:
-    //  1. Allow only letters, numbers and single dashes
-    //  2. Must not start or end with a dash
-    // regex: ^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$
-    let mut chars = name.chars();
-    match chars.next() {
-        Some(c) if c.is_ascii_alphanumeric() => {}
-        _ => return false,
-    }
-    let mut was_dash = false;
-    for c in chars {
-        if c == '-' {
-            if was_dash {
-                return false;
-            } else {
-                was_dash = true;
-            }
-        } else {
-            if !c.is_ascii_alphanumeric() {
-                return false;
-            }
-            was_dash = false;
-        }
-    }
-    !was_dash
-}
-
-pub fn is_valid_cloud_org_name(name: &str) -> bool {
-    // For cloud organization slug part:
-    //  1. Allow only letters, numbers, underscores and single dashes
-    //  2. Must not end with a dash
-    // regex: ^-?[a-zA-Z0-9_]+(-[a-zA-Z0-9]+)*$
-    let mut chars = name.chars();
-    match chars.next() {
-        Some(c) if c.is_ascii_alphanumeric() || c == '-' || c == '_' => {}
-        _ => return false,
-    }
-    let mut was_dash = false;
-    for c in chars {
-        if c == '-' {
-            if was_dash {
-                return false;
-            } else {
-                was_dash = true;
-            }
-        } else {
-            if !(c.is_ascii_alphanumeric() || c == '_') {
-                return false;
-            }
-            was_dash = false;
-        }
-    }
-    !was_dash
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/portable/local.rs
+++ b/src/portable/local.rs
@@ -10,6 +10,7 @@ use std::time::SystemTime;
 use anyhow::Context;
 use fn_error_context::context;
 
+use gel_dsn::gel::UnixPath;
 use gel_tokio::{Builder, Config};
 
 use crate::branding::BRANDING;
@@ -378,7 +379,9 @@ impl InstanceInfo {
     pub fn admin_conn_params(&self) -> anyhow::Result<Config> {
         let config = Builder::new()
             .port(self.port)
-            .unix_path(&runstate_dir(&self.name)?)
+            .unix_path(UnixPath::with_port_suffix(
+                runstate_dir(&self.name)?.join(".s.EDGEDB.admin."),
+            ))
             .wait_until_available(std::time::Duration::from_secs(300))
             .without_system()
             .build()?;

--- a/src/portable/project/info.rs
+++ b/src/portable/project/info.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 
 use clap::ValueHint;
 use const_format::concatcp;
-use gel_tokio::get_stash_path;
 
 use crate::branding::BRANDING_CLI_CMD;
 use crate::branding::BRANDING_CLOUD;
@@ -11,6 +10,8 @@ use crate::commands::ExitCode;
 use crate::portable::project;
 use crate::print::{self, msg, Highlight};
 use crate::table;
+
+use super::get_stash_path;
 
 pub fn run(options: &Command) -> anyhow::Result<()> {
     let ctx = project::ensure_ctx(options.project_dir.as_deref())?;

--- a/src/portable/project/unlink.rs
+++ b/src/portable/project/unlink.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use clap::ValueHint;
-use gel_tokio::get_stash_path;
 
 use crate::branding::MANIFEST_FILE_DISPLAY_NAME;
 use crate::commands::ExitCode;
@@ -13,6 +12,8 @@ use crate::portable::instance::destroy;
 use crate::portable::project;
 use crate::print::{self, msg, Highlight};
 use crate::question;
+
+use super::get_stash_path;
 
 pub fn run(options: &Command, opts: &crate::options::Options) -> anyhow::Result<()> {
     let Some(project) = project::find_project(options.project_dir.as_deref())? else {

--- a/src/portable/project/upgrade.rs
+++ b/src/portable/project/upgrade.rs
@@ -3,7 +3,6 @@ use std::str::FromStr;
 
 use anyhow::Context;
 use clap::ValueHint;
-use gel_tokio::get_stash_path;
 
 use crate::branding::{BRANDING, BRANDING_CLI_CMD};
 use crate::cloud;
@@ -20,6 +19,8 @@ use crate::portable::ver;
 use crate::portable::windows;
 use crate::print::{self, msg, AsRelativeToCurrentDir, Highlight};
 use crate::question;
+
+use super::get_stash_path;
 
 pub fn run(options: &Command, opts: &crate::options::Options) -> anyhow::Result<()> {
     let (query, version_set) = Query::from_options(

--- a/tests/shared-client-tests/build.rs
+++ b/tests/shared-client-tests/build.rs
@@ -36,33 +36,25 @@ fn main() {
     ]);
     let error_mapping = HashMap::from([
         ("invalid_dsn", "(invalid DSN|Invalid DSN)"),
-        ("env_not_found", "is not set"),
+        ("env_not_found", "not set"),
         (
             "invalid_tls_security",
-            "((EDGEDB_CLIENT_TLS_SECURITY|tls_security).*(don't comply|Invalid value)|\
-            Unsupported TLS security|Insecure TLS configuration is not allowed in strict mode)",
+            "Invalid TLS security|Unsupported TLS security",
         ),
         (
             "file_not_found",
-            "(No such file or directory)|(cannot find the path)|\
-            (a value is required for)",
+            "File not found|but none was supplied",
         ),
-        ("invalid_host", "invalid host"),
+        ("invalid_host", "Invalid host"),
         (
             "invalid_port",
-            "(invalid value.*for.*port|invalid port|EDGEDB_PORT is invalid)",
+            "Invalid port|invalid digit found in string|cannot parse integer from empty string|is not in",
         ),
-        (
-            "invalid_dsn_or_instance_name",
-            "(invalid DSN|must be a valid identifier)",
-        ),
+        ("invalid_dsn_or_instance_name", "(Invalid instance name|Invalid DSN)"),
         ("invalid_instance_name", "invalid.*instance name"),
-        ("invalid_user", "invalid user"),
-        ("invalid_database", "invalid database"),
-        (
-            "invalid_credentials_file",
-            "(cannot read credentials file)|(a value is required for)",
-        ),
+        ("invalid_user", "Invalid user"),
+        ("invalid_database", "Invalid database"),
+        ("invalid_credentials_file", "Invalid credentials file|but none was supplied"),
         (
             "no_options_or_toml",
             "no .*toml.* found and no connection options are specified",
@@ -73,8 +65,7 @@ fn main() {
         ),
         (
             "multiple_compound_env",
-            "multiple compound env vars found|\
-             [A-Z]+\\s*conflicts\\s*with\\s*[A-Z]+",
+            "Multiple compound environment variables",
         ),
         (
             "exclusive_options",
@@ -82,11 +73,12 @@ fn main() {
         ),
         (
             "credentials_file_not_found",
-            "credentials file.*No such file",
+            "file not found",
         ),
         ("project_not_initialised", "not initialized"),
-        ("secret_key_not_found", "NoCloudConfigFound"),
-        ("invalid_secret_key", "Illegal JWT token"),
+        ("secret_key_not_found", "Secret key not found"),
+        ("invalid_secret_key", "Invalid secret key"),
+        ("unix_socket_unsupported", "Unix socket unsupported|must be a hostname"),
     ]);
 
     let out_dir = env::var_os("OUT_DIR").unwrap();
@@ -166,17 +158,7 @@ static MUTEX: Mutex<()> = Mutex::new(());
             if let Some(dsn) = opts.get("dsn") {
                 if let Some(dsn) = dsn.as_str() {
                     // servo/rust-url#424
-                    if dsn.contains("%25eth0")
-                        || dsn.starts_with("edgedbadmin://")
-                        || dsn.contains("host=/")
-                    {
-                        should_panic = true;
-                    }
-                }
-            }
-            if let Some(host) = opts.get("host") {
-                if let Some(host) = host.as_str() {
-                    if host.starts_with('/') {
+                    if dsn.contains("%25eth0") {
                         should_panic = true;
                     }
                 }

--- a/tests/shared-client-tests/tests/shared_client_tests.rs
+++ b/tests/shared-client-tests/tests/shared_client_tests.rs
@@ -8,6 +8,7 @@ use std::fmt::{Display, Formatter};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 struct ResultPredicate {
     result: Value,
@@ -25,10 +26,10 @@ impl Predicate<str> for ResultPredicate {
             match self.result.get(k) {
                 Some(expected) if k == "waitUntilAvailable" => {
                     let expected = expected.as_str().unwrap().parse::<Duration>().unwrap();
-                    if v.as_i64().is_none() {
+                    if v.as_str().is_none() {
                         panic!("illegal waitUntilAvailable: {}", v);
                     }
-                    let v = Duration::from_micros(v.as_i64().unwrap());
+                    let v = Duration::from_str(v.as_str().unwrap()).unwrap();
                     if expected != v {
                         println!("{}: {} != {}", k, v, expected);
                         return false;


### PR DESCRIPTION
The `gel-dsn` library replaces the previous connection argument parsing. There are some minor API changes that we need to update here.