### PR TITLE
Add a progress bar to restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fn-stream"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e71711442f1016c768c259bec59300a10efe753bc3e686ec19e2c6a54a97c29b"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1455,6 +1465,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "assert_cmd",
+ "async-fn-stream",
  "backtrace",
  "base32",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ geozero = {version="0.14.0", features=["with-wkb"]}
 terminal-light = {git = "https://github.com/msullivan/terminal-light"}
 globset = "0.4.15"
 x509-parser = "0.17.0"
+async-fn-stream = "0.2.2"
 
 [dependencies.bzip2]
 version = "*"

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -171,6 +171,7 @@ impl<T: Stream<Item = Result<Bytes, Error>> + Unpin> Stream for StreamWithProgre
                 ));
             }
         } else {
+            this.bar.set_message("Processing data");
             this.bar.finish();
         }
         Poll::Ready(next)


### PR DESCRIPTION
Adds a progress bar to restore. Also fixes a potential issue where the packet reader could throw away bytes.

```
Restoring database from file `/tmp/foo/dump`. Total size: 2756.21 MB
⠂ Restoring database: 733.42 MiB/2.69 GiB processed (32.04 MiB/s)                                                                                                                                                                                                                     
```

It's not obvious from the previous Packet implementation that it is fully-cancellation safe, though it does appear to be using cancellation-safe I/O methods. Instead of trying to prove that all paths are cancellation-safe, it was rewritten to use `async_fn_stream`. Benchmarking shows no performance impact and the code is now obviously cancellation safe and in the case where futures may return pending, does not perform more work than necessary.
