### PR TITLE
Avoid producing an error message about rm failing

### DIFF
--- a/edgedb-init.sh
+++ b/edgedb-init.sh
@@ -123,7 +123,7 @@ main() {
 
     local _retval=$?
 
-    ignore rm "$_file"
+    ignore rm "$_file" 2> /dev/null  # CLI will try to remove self
     ignore rmdir "$_dir"
 
     return "$_retval"


### PR DESCRIPTION
The install script frequently produces a harmless error message like:
```
rm: can't remove '/tmp/tmp.eGmFJl/edgedb': No such file or directory
```

I think this is because the cli tries to rename itself to the
installation location, and so the file might not be there. It doesn't
always succeed, though, so we still need to do the `rm`.
(It will fail if /tmp is on a different drive, for example.)
This has been reported recently a few times; it seems like it
must have been around before, though?

I routed the output to /dev/null instead of specifying `-f` out of
nervousness.