### PR TITLE
Fix instance list with Cloud instances

### DIFF
--- a/src/cloud/ops.rs
+++ b/src/cloud/ops.rs
@@ -23,6 +23,7 @@ const SPINNER_TICK: Duration = Duration::from_millis(100);
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct CloudInstance {
     pub id: String,
+    #[serde(flatten)]
     name: CloudName,
     dsn: String,
     pub status: String,


### PR DESCRIPTION
The API returns `org_slug` and `name` on the same level, instead of nested object.

Refs #1527
Fixes #1544 