### PR TITLE
Tweak writing of credentials in instance create

### DIFF
--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -77,6 +77,8 @@ pub fn maybe_update_credentials_file(config: &Config, ask: bool) -> anyhow::Resu
                     &std::fs::read_to_string(&creds_path).unwrap_or_default(),
                 )?;
                 if new != old {
+                    log::debug!("old: {old}");
+                    log::debug!("new: {new}");
                     if !ask
                         || question::Confirm::new(format!(
                             "The format of the instance credential file at {} is outdated, \
@@ -85,7 +87,7 @@ pub fn maybe_update_credentials_file(config: &Config, ask: bool) -> anyhow::Resu
                         ))
                         .ask()?
                     {
-                        std::fs::write(&creds_path, &new.to_string())?;
+                        std::fs::write(&creds_path, new.to_string())?;
                     }
                 }
             }


### PR DESCRIPTION
The recent migration to gel-dns introduced a "new" credentials.json format, which differs from the old in that it contains "applied defaults" instead of missing fields which imply defaults.

This PR makes sure that `gel instance create` writes `credentials.json` with the new format so user is not prompted to update the format right after creation.