### PR TITLE
Use -I in instance create

### DIFF
--- a/src/portable/instance/create.rs
+++ b/src/portable/instance/create.rs
@@ -53,7 +53,7 @@ pub fn run(cmd: &Command, opts: &crate::options::Options) -> anyhow::Result<()> 
     }
 
     let mut client = cloud::client::CloudClient::new(&opts.cloud_options)?;
-    let inst_name = if let Some(name) = &cmd.name {
+    let inst_name = if let Some(name) = cmd.name.as_ref().or(cmd.instance.as_ref()) {
         name.to_owned()
     } else if cmd.non_interactive {
         msg!(
@@ -189,6 +189,9 @@ pub struct Command {
     /// Name of instance to create. Asked interactively if not specified.
     #[arg(value_hint=clap::ValueHint::Other)]
     pub name: Option<InstanceName>,
+
+    #[arg(from_global)]
+    pub instance: Option<InstanceName>,
 
     /// Create instance using the latest nightly version.
     #[arg(long, conflicts_with_all=&["channel", "version"])]

--- a/src/portable/project/init.rs
+++ b/src/portable/project/init.rs
@@ -334,6 +334,7 @@ fn do_init(
         windows::create_instance(
             &create::Command {
                 name: Some(inst_name.clone()),
+                instance: None,
                 nightly: false,
                 channel: q.cli_channel(),
                 version: q.version,

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -231,6 +231,7 @@ pub fn create_instance(
 
     let inner_options = create::Command {
         name: Some(options::InstanceName::Local(name.to_string())),
+        instance: None,
         port: Some(port),
         ..options.clone()
     };


### PR DESCRIPTION
We have a global -I (--instance) for specifying instances.
`instance create` has a distinct name argument, which does not
read the global -I arg.

This PR makes the name arg fallback to the global -I.

Closes #1537
