### PR TITLE
Start refactoring cloud API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,7 +1518,6 @@ dependencies = [
  "assert_cmd",
  "async-fn-stream",
  "backtrace",
- "base64 0.22.1",
  "bigdecimal",
  "bitflags 2.9.0",
  "bitvec",
@@ -1649,7 +1648,9 @@ name = "gel-cli-instance"
 version = "7.2.0-dev"
 dependencies = [
  "bytes",
+ "clap",
  "derive_more",
+ "humantime-serde",
  "log",
  "rstest",
  "scopeguard",
@@ -1734,6 +1735,8 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror 2.0.12",
+ "tracing",
+ "uuid",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ gel-errors = { version = "0.5" }
 gel-auth = { version = "0.1" }
 gel-tokio = { version = "0.10", features=["admin_socket", "unstable"] }
 gel-dsn = { version = "0.2", features = ["unstable", "gel", "auto-log-trace", "auto-log-warning"] }
-gel-jwt = { version = "0.1" }
+gel-jwt = { version = "0.1", features = ["gel"] }
 
 gel-cli-instance = { path = "./gel-cli-instance" }
 gel-cli-derive = { path = "./gel-cli-derive" }
@@ -70,7 +70,7 @@ terminal_size = "0.4"
 bigdecimal = "0.4"
 num-bigint = "0.4.3"
 humantime = "2.0.0"
-humantime-serde = "1.0.0"
+humantime-serde = "1"
 once_cell = "1.3.1"
 unicode-segmentation = "1.6.0"
 unicode-width = "0.1.10"
@@ -103,7 +103,6 @@ fn-error-context = "0.2"
 combine = "4.2.1"
 sha2 = "0.10.2"
 rand = "0.8.2"
-base64 = "0.22.1"
 shell-escape = "0.1.5"
 indicatif = "0.17.0"
 url = { version = "2.1.1", features=["serde"] }

--- a/gel-cli-instance/Cargo.toml
+++ b/gel-cli-instance/Cargo.toml
@@ -14,5 +14,9 @@ log = "0.4"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
-derive_more = { version = "2", features = ["error"] }
+derive_more = { version = "2", features = ["error", "display"] }
+humantime-serde = "1.1.1"
+clap = "4"
+
+[dev-dependencies]
 rstest = "0.25"

--- a/gel-cli-instance/src/cloud/mod.rs
+++ b/gel-cli-instance/src/cloud/mod.rs
@@ -1,0 +1,367 @@
+use humantime_serde::re::humantime;
+use serde::{Serialize, de::DeserializeOwned};
+use std::{collections::HashMap, fmt::Debug};
+
+mod schema;
+pub use schema::*;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CloudError {
+    #[error(
+        "Permission error while attempting to make an HTTP request. This may be due to a firewall blocking the request."
+    )]
+    PermissionError,
+    #[error("I/O error while attempting to make an HTTP request: {0} {1}")]
+    OtherIo(std::io::ErrorKind, String),
+    #[error("Unauthorized")]
+    Unauthorized,
+    #[error("Not found: {0}")]
+    NotFound(String),
+    #[error("Bad request: {0}")]
+    BadRequest(String),
+    #[error("HTTP error {0}: {1}")]
+    Other(u16, String),
+    #[error("Invalid request: {0}")]
+    InvalidRequest(String),
+    #[error("Communication error: {0}")]
+    CommunicationError(Box<dyn std::error::Error + Send + Sync>),
+    #[error("Deserialization error: {0}")]
+    DeserializationError(Box<dyn std::error::Error + Send + Sync>),
+}
+
+#[allow(async_fn_in_trait)]
+pub trait CloudHttp {
+    async fn get<T: DeserializeOwned + Debug>(
+        &self,
+        what: impl std::fmt::Display,
+        url: &str,
+    ) -> Result<T, CloudError>;
+    async fn post<REQ: Serialize + Debug, RES: DeserializeOwned + Debug>(
+        &self,
+        what: impl std::fmt::Display,
+        url: &str,
+        body: REQ,
+    ) -> Result<RES, CloudError>;
+    async fn put<REQ: Serialize + Debug, RES: DeserializeOwned + Debug>(
+        &self,
+        what: impl std::fmt::Display,
+        url: &str,
+        body: REQ,
+    ) -> Result<RES, CloudError>;
+    async fn delete<T: DeserializeOwned + Debug>(
+        &self,
+        what: impl std::fmt::Display,
+        url: &str,
+    ) -> Result<T, CloudError>;
+}
+
+pub struct CloudApi<H: CloudHttp> {
+    http: H,
+    endpoint: String,
+}
+
+impl<H: CloudHttp> CloudApi<H> {
+    pub fn new(http: H, endpoint: String) -> Self {
+        Self { http, endpoint }
+    }
+
+    fn endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.endpoint, path)
+    }
+}
+
+#[derive(Debug, Clone, derive_more::Display)]
+enum CloudResource<'a> {
+    #[display("current user")]
+    User,
+    #[display("user session with id '{_0}'")]
+    UserSession(&'a str),
+    #[display("user sessions")]
+    UserSessions,
+    #[display("cloud operation with id '{_0}'")]
+    CloudOperation(&'a str),
+    #[display("instances")]
+    Instances,
+    #[display("instance with name '{_0}/{_1}'")]
+    Instance(&'a str, &'a str),
+    #[display("organization with name '{_0}'")]
+    Org(&'a str),
+    #[display("secret keys")]
+    SecretKeys,
+    #[display("secret key with id '{_0}'")]
+    SecretKey(&'a str),
+    #[display("versions")]
+    Versions,
+    #[display("pricing")]
+    Pricing,
+    #[display("region")]
+    Region,
+}
+
+impl<H: CloudHttp> CloudApi<H> {
+    pub async fn get_user(&self) -> Result<schema::User, CloudError> {
+        self.http
+            .get(CloudResource::User, &self.endpoint("user"))
+            .await
+    }
+
+    pub async fn create_session(
+        &self,
+        session_type: &str,
+    ) -> Result<schema::UserSessionCreated, CloudError> {
+        // TODO: API mismatch?
+        let body = HashMap::from([("type", session_type)]);
+        self.http
+            .post(
+                CloudResource::UserSessions,
+                &self.endpoint("auth/sessions"),
+                body,
+            )
+            .await
+    }
+
+    pub async fn get_session(&self, session_id: &str) -> Result<schema::UserSession, CloudError> {
+        self.http
+            .get(
+                CloudResource::UserSession(session_id),
+                &self.endpoint(&format!("auth/sessions/{}", session_id)),
+            )
+            .await
+    }
+
+    pub async fn get_operation(
+        &self,
+        operation_id: &str,
+    ) -> Result<schema::CloudOperation, CloudError> {
+        self.http
+            .get(
+                CloudResource::CloudOperation(operation_id),
+                &self.endpoint(&format!("operations/{}", operation_id)),
+            )
+            .await
+    }
+
+    pub async fn list_instances(&self) -> Result<Vec<schema::CloudInstance>, CloudError> {
+        self.http
+            .get(CloudResource::Instances, &self.endpoint("instances"))
+            .await
+    }
+
+    pub async fn get_instance(
+        &self,
+        org_slug: &str,
+        name: &str,
+    ) -> Result<schema::CloudInstance, CloudError> {
+        self.http
+            .get(
+                CloudResource::Instance(org_slug, name),
+                &self.endpoint(&format!("orgs/{org_slug}/instances/{name}")),
+            )
+            .await
+    }
+
+    pub async fn delete_instance(
+        &self,
+        org_slug: &str,
+        name: &str,
+    ) -> Result<schema::CloudOperation, CloudError> {
+        self.http
+            .delete(
+                CloudResource::Instance(org_slug, name),
+                &self.endpoint(&format!("orgs/{org_slug}/instances/{name}")),
+            )
+            .await
+    }
+
+    pub async fn create_instance(
+        &self,
+        org_slug: &str,
+        request: schema::CloudInstanceCreate,
+    ) -> Result<schema::CloudOperation, CloudError> {
+        self.http
+            .post(
+                CloudResource::Instance(org_slug, &request.name.to_owned()),
+                &self.endpoint(&format!("orgs/{org_slug}/instances")),
+                request,
+            )
+            .await
+    }
+
+    pub async fn upgrade_instance(
+        &self,
+        org_slug: &str,
+        name: &str,
+        request: schema::CloudInstanceUpgrade,
+    ) -> Result<schema::CloudOperation, CloudError> {
+        self.http
+            .put(
+                CloudResource::Instance(org_slug, name),
+                &self.endpoint(&format!("orgs/{org_slug}/instances/{name}")),
+                request,
+            )
+            .await
+    }
+
+    pub async fn resize_instance(
+        &self,
+        org_slug: &str,
+        name: &str,
+        request: schema::CloudInstanceResize,
+    ) -> Result<schema::CloudOperation, CloudError> {
+        self.http
+            .put(
+                CloudResource::Instance(org_slug, name),
+                &self.endpoint(&format!("orgs/{org_slug}/instances/{name}")),
+                request,
+            )
+            .await
+    }
+
+    pub async fn get_org(&self, org_slug: &str) -> Result<schema::Org, CloudError> {
+        self.http
+            .get(
+                CloudResource::Org(org_slug),
+                &self.endpoint(&format!("orgs/{org_slug}")),
+            )
+            .await
+    }
+
+    pub async fn create_backup(
+        &self,
+        org_slug: &str,
+        name: &str,
+    ) -> Result<schema::CloudOperation, CloudError> {
+        // TODO: Missing API in doc
+        self.http
+            .post(
+                CloudResource::Instance(org_slug, name),
+                &self.endpoint(&format!("orgs/{org_slug}/instances/{name}/backups")),
+                {},
+            )
+            .await
+    }
+
+    pub async fn list_backups(
+        &self,
+        org_slug: &str,
+        name: &str,
+    ) -> Result<Vec<schema::Backup>, CloudError> {
+        self.http
+            .get(
+                CloudResource::Instance(org_slug, name),
+                &self.endpoint(&format!("orgs/{org_slug}/instances/{name}/backups")),
+            )
+            .await
+    }
+
+    pub async fn restore_instance(
+        &self,
+        org_slug: &str,
+        name: &str,
+        request: schema::CloudInstanceRestore,
+    ) -> Result<schema::CloudOperation, CloudError> {
+        self.http
+            .post(
+                CloudResource::Instance(org_slug, name),
+                &self.endpoint(&format!("orgs/{org_slug}/instances/{name}/restore")),
+                request,
+            )
+            .await
+    }
+
+    pub async fn restart_instance(
+        &self,
+        org_slug: &str,
+        name: &str,
+    ) -> Result<schema::CloudOperation, CloudError> {
+        self.http
+            .post(
+                CloudResource::Instance(org_slug, name),
+                &self.endpoint(&format!("orgs/{org_slug}/instances/{name}/restart")),
+                {},
+            )
+            .await
+    }
+
+    pub async fn get_instance_logs(
+        &self,
+        org_slug: &str,
+        name: &str,
+        limit: Option<usize>,
+        start: Option<std::time::SystemTime>,
+        to: Option<std::time::SystemTime>,
+        direction: Option<&str>,
+    ) -> Result<schema::Logs, CloudError> {
+        let mut query_params = Vec::new();
+        if let Some(limit) = limit {
+            query_params.push(format!("limit={}", limit));
+        }
+        if let Some(start) = start {
+            query_params.push(format!("start={}", humantime::format_rfc3339(start)));
+        }
+        if let Some(to) = to {
+            query_params.push(format!("to={}", humantime::format_rfc3339(to)));
+        }
+        if let Some(direction) = direction {
+            query_params.push(format!("direction={}", direction));
+        }
+        self.http
+            .get(
+                CloudResource::Instance(org_slug, name),
+                &self.endpoint(&format!(
+                    "orgs/{org_slug}/instances/{name}/logs?{}",
+                    query_params.join("&")
+                )),
+            )
+            .await
+    }
+
+    pub async fn create_secret_key(
+        &self,
+        input: schema::CreateSecretKeyInput,
+    ) -> Result<schema::SecretKey, CloudError> {
+        self.http
+            .post(
+                CloudResource::SecretKeys,
+                &self.endpoint("secretkeys/"),
+                input,
+            )
+            .await
+    }
+
+    pub async fn list_secret_keys(&self) -> Result<Vec<schema::SecretKey>, CloudError> {
+        self.http
+            .get(CloudResource::SecretKeys, &self.endpoint("secretkeys/"))
+            .await
+    }
+
+    pub async fn delete_secret_key(
+        &self,
+        secret_key_id: &str,
+    ) -> Result<schema::SecretKey, CloudError> {
+        self.http
+            .delete(
+                CloudResource::SecretKey(secret_key_id),
+                &self.endpoint(&format!("secretkeys/{}", secret_key_id)),
+            )
+            .await
+    }
+
+    pub async fn get_versions(&self) -> Result<Vec<schema::Version>, CloudError> {
+        self.http
+            .get(CloudResource::Versions, &self.endpoint("versions"))
+            .await
+    }
+
+    pub async fn get_prices(&self) -> Result<schema::PricesResponse, CloudError> {
+        self.http
+            .get(CloudResource::Pricing, &self.endpoint("pricing"))
+            .await
+    }
+
+    pub async fn get_current_region(&self) -> Result<schema::Region, CloudError> {
+        self.http
+            .get(CloudResource::Region, &self.endpoint("region/self"))
+            .await
+    }
+}

--- a/gel-cli-instance/src/cloud/schema.rs
+++ b/gel-cli-instance/src/cloud/schema.rs
@@ -1,0 +1,225 @@
+use std::collections::HashMap;
+
+#[derive(Debug, serde::Deserialize)]
+pub struct User {
+    pub name: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct UserSessionCreated {
+    pub id: String,
+    pub auth_url: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct UserSession {
+    pub id: String,
+    pub token: Option<String>,
+    pub auth_url: String,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct Backup {
+    pub id: String,
+
+    #[serde(with = "humantime_serde")]
+    pub created_on: std::time::SystemTime,
+
+    pub status: String,
+    pub r#type: String,
+    pub edgedb_version: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct CloudInstanceBackup {
+    pub name: String,
+    pub org: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct CloudInstanceRestore {
+    pub backup_id: Option<String>,
+    pub latest: bool,
+    pub source_instance_id: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct CloudInstance {
+    pub id: String,
+    pub name: String,
+    pub org_slug: String,
+    pub dsn: String,
+    pub status: String,
+    pub version: String,
+    pub region: String,
+    pub tier: CloudTier,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tls_ca: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ui_url: Option<String>,
+    pub billables: Vec<CloudInstanceResource>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct CloudInstanceResource {
+    pub name: String,
+    pub display_name: String,
+    pub display_unit: String,
+    pub display_quota: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[allow(dead_code)]
+pub struct Org {
+    pub id: String,
+    pub name: String,
+    pub preferred_payment_method: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[allow(dead_code)]
+pub struct Region {
+    pub name: String,
+    pub platform: String,
+    pub platform_region: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct Version {
+    pub version: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[allow(dead_code)]
+pub struct Price {
+    pub billable: String,
+    pub unit_price_cents: String,
+    pub units_bundled: Option<String>,
+    pub units_default: Option<String>,
+}
+
+pub type Prices = HashMap<CloudTier, HashMap<String, Vec<Price>>>;
+
+#[derive(Debug, serde::Deserialize)]
+pub struct Billable {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct PricesResponse {
+    pub prices: Prices,
+    pub billables: Vec<Billable>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct CloudInstanceResourceRequest {
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+    clap::ValueEnum,
+    derive_more::Display,
+)]
+pub enum CloudTier {
+    Pro,
+    Free,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct SecretKey {
+    pub id: String,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub scopes: Vec<String>,
+
+    #[serde(with = "humantime_serde")]
+    pub created_on: std::time::SystemTime,
+
+    #[serde(with = "humantime_serde")]
+    pub expires_on: Option<std::time::SystemTime>,
+
+    pub secret_key: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct CreateSecretKeyInput {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub scopes: Option<Vec<String>>,
+    pub ttl: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct CloudInstanceCreate {
+    pub name: String,
+    pub version: String,
+    pub region: Option<String>,
+    pub requested_resources: Option<Vec<CloudInstanceResourceRequest>>,
+    pub tier: Option<CloudTier>,
+    pub source_instance_id: Option<String>,
+    pub source_backup_id: Option<String>,
+    // #[serde(skip_serializing_if = "Option::is_none")]
+    // pub default_database: Option<String>,
+    // #[serde(skip_serializing_if = "Option::is_none")]
+    // pub default_user: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct CloudInstanceResize {
+    pub requested_resources: Option<Vec<CloudInstanceResourceRequest>>,
+    pub tier: Option<CloudTier>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct CloudInstanceUpgrade {
+    pub version: String,
+    pub force: bool,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct CloudInstanceRestart {}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OperationStatus {
+    InProgress,
+    Failed,
+    Completed,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct CloudOperation {
+    pub id: String,
+    pub status: OperationStatus,
+    pub description: String,
+    pub message: String,
+    pub subsequent_id: Option<String>,
+}
+
+pub struct Log {
+    pub logs: Vec<LogEntry>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct LogEntry {
+    pub service: String,
+    pub severity: String,
+    #[serde(with = "humantime_serde")]
+    pub time: std::time::SystemTime,
+    pub log: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct Logs {
+    pub logs: Vec<LogEntry>,
+}

--- a/gel-cli-instance/src/lib.rs
+++ b/gel-cli-instance/src/lib.rs
@@ -13,6 +13,7 @@ use scopeguard::{self, ScopeGuard};
 use serde_json::de::SliceRead;
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt};
 
+pub mod cloud;
 pub mod docker;
 
 #[derive(derive_more::Error, derive_more::Display, Debug)]

--- a/src/cloud/backups.rs
+++ b/src/cloud/backups.rs
@@ -1,52 +1,17 @@
+use gel_cli_instance::cloud::{Backup, CloudInstanceRestore, CloudOperation};
+
 use crate::table::{self, Cell, Row, Table};
 
-use crate::cloud::client::{CloudClient, ErrorResponse};
-use crate::cloud::ops::{CloudOperation, wait_for_operation};
-
-#[derive(Debug, serde::Deserialize, serde::Serialize)]
-pub struct Backup {
-    pub id: String,
-
-    #[serde(with = "humantime_serde")]
-    pub created_on: std::time::SystemTime,
-
-    pub status: String,
-    pub r#type: String,
-    pub edgedb_version: String,
-}
-
-#[derive(Debug, serde::Serialize)]
-pub struct CloudInstanceBackup {
-    pub name: String,
-    pub org: String,
-}
-
-#[derive(Debug, serde::Serialize)]
-pub struct CloudInstanceRestore {
-    pub name: String,
-    pub org: String,
-    pub backup_id: Option<String>,
-    pub latest: bool,
-    pub source_instance_id: Option<String>,
-}
+use crate::cloud::client::CloudClient;
+use crate::cloud::ops::wait_for_operation;
 
 #[tokio::main(flavor = "current_thread")]
 pub async fn backup_cloud_instance(
     client: &CloudClient,
-    request: &CloudInstanceBackup,
+    org: &str,
+    name: &str,
 ) -> anyhow::Result<()> {
-    let url = format!("orgs/{}/instances/{}/backups", request.org, request.name);
-    let operation: CloudOperation = client.post(url, request).await.or_else(|e| match e
-        .downcast_ref::<ErrorResponse>(
-    ) {
-        Some(ErrorResponse {
-            code: reqwest::StatusCode::NOT_FOUND,
-            ..
-        }) => {
-            anyhow::bail!("specified instance could not be found",);
-        }
-        _ => Err(e),
-    })?;
+    let operation = client.api.create_backup(org, name).await?;
     wait_for_operation(operation, client).await?;
     Ok(())
 }
@@ -54,20 +19,24 @@ pub async fn backup_cloud_instance(
 #[tokio::main(flavor = "current_thread")]
 pub async fn restore_cloud_instance(
     client: &CloudClient,
-    request: &CloudInstanceRestore,
+    org_slug: &str,
+    name: &str,
+    latest: bool,
+    backup_id: Option<String>,
+    source_instance_id: Option<String>,
 ) -> anyhow::Result<()> {
-    let url = format!("orgs/{}/instances/{}/restore", request.org, request.name);
-    let operation: CloudOperation = client.post(url, request).await.or_else(|e| match e
-        .downcast_ref::<ErrorResponse>(
-    ) {
-        Some(ErrorResponse {
-            code: reqwest::StatusCode::NOT_FOUND,
-            ..
-        }) => {
-            anyhow::bail!("specified instance or backup could not be found",);
-        }
-        _ => Err(e),
-    })?;
+    let operation: CloudOperation = client
+        .api
+        .restore_instance(
+            org_slug,
+            name,
+            CloudInstanceRestore {
+                backup_id,
+                latest,
+                source_instance_id,
+            },
+        )
+        .await?;
     wait_for_operation(operation, client).await?;
     Ok(())
 }
@@ -79,8 +48,7 @@ pub async fn list_cloud_instance_backups(
     name: &str,
     json: bool,
 ) -> anyhow::Result<()> {
-    let url = format!("orgs/{org_slug}/instances/{name}/backups");
-    let backups: Vec<Backup> = client.get(url).await?;
+    let backups: Vec<Backup> = client.api.list_backups(org_slug, name).await?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&backups)?);

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -96,6 +96,7 @@ impl<'a> Iterator for ToDo<'a> {
 
 pub fn main(options: Options, cfg: Config) -> Result<(), anyhow::Error> {
     print_logo(false, true);
+
     let (control_wr, control_rd) = channel(1);
     let conn = options.block_on_create_connector()?;
     let limit = cfg.shell.limit.unwrap_or(100);

--- a/src/portable/instance/backup.rs
+++ b/src/portable/instance/backup.rs
@@ -111,11 +111,7 @@ fn backup_cloud_cmd(
         return Ok(());
     }
 
-    let request = cloud::backups::CloudInstanceBackup {
-        name: name.to_string(),
-        org: org_slug.to_string(),
-    };
-    cloud::backups::backup_cloud_instance(&client, &request)?;
+    cloud::backups::backup_cloud_instance(&client, org_slug, name)?;
 
     msg!("Successfully created a backup for {BRANDING_CLOUD} instance {inst_name}");
     Ok(())
@@ -195,14 +191,14 @@ fn restore_cloud_cmd(
         return Ok(());
     }
 
-    let request = cloud::backups::CloudInstanceRestore {
-        name: name.to_string(),
-        org: org_slug.to_string(),
-        backup_id: backup.backup_id.clone(),
-        latest: backup.latest,
-        source_instance_id: source_inst.map(|i| i.id),
-    };
-    cloud::backups::restore_cloud_instance(&client, &request)?;
+    cloud::backups::restore_cloud_instance(
+        &client,
+        org_slug,
+        name,
+        backup.latest,
+        backup.backup_id.clone(),
+        source_inst.map(|i| i.id),
+    )?;
 
     msg!("{BRANDING_CLOUD} instance {inst_name} has been restored successfully.");
     msg!("To connect to the instance run:");

--- a/src/portable/instance/control.rs
+++ b/src/portable/instance/control.rs
@@ -602,13 +602,15 @@ pub fn restart(cmd: &Restart, options: &crate::Options) -> anyhow::Result<()> {
     }
 }
 
-pub fn logs(options: &Logs) -> anyhow::Result<()> {
-    if cfg!(windows) {
-        windows::logs(options)
+pub fn logs(cmd: &Logs, options: &crate::Options) -> anyhow::Result<()> {
+    if let InstanceName::Cloud { org_slug, name } = cmd.instance_opts.instance()? {
+        crate::cloud::ops::logs_cloud_instance(&name, &org_slug, cmd.tail, &options.cloud_options)
+    } else if cfg!(windows) {
+        windows::logs(cmd)
     } else if cfg!(target_os = "macos") {
-        macos::logs(options)
+        macos::logs(cmd)
     } else if cfg!(target_os = "linux") {
-        linux::logs(options)
+        linux::logs(cmd)
     } else {
         anyhow::bail!("unsupported platform");
     }

--- a/src/portable/instance/mod.rs
+++ b/src/portable/instance/mod.rs
@@ -36,7 +36,7 @@ pub fn run(cmd: &Command, options: &Options) -> Result<(), anyhow::Error> {
         Restart(c) if cfg!(windows) => windows::restart(c),
         Restart(c) => control::restart(c, options),
         Logs(c) if cfg!(windows) => windows::logs(c),
-        Logs(c) => control::logs(c),
+        Logs(c) => control::logs(c, options),
         Revert(c) => revert::run(c),
         Unlink(c) => unlink::run(c),
         Status(c) if cfg!(windows) => windows::status(c),

--- a/src/portable/instance/resize.rs
+++ b/src/portable/instance/resize.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use color_print::cformat;
 use gel_cli_derive::IntoArgs;
+use gel_cli_instance::cloud::{CloudInstanceResize, CloudInstanceResourceRequest, CloudTier};
 
 use crate::branding::{BRANDING_CLI_CMD, BRANDING_CLOUD};
 use crate::cloud;
@@ -87,7 +88,7 @@ fn resize_cloud_cmd(
             ))?;
         }
 
-        if tier == cloud::ops::CloudTier::Free {
+        if tier == CloudTier::Free {
             if compute_size.is_some() {
                 Err(opts.error(
                     clap::error::ErrorKind::ArgumentConflict,
@@ -146,10 +147,10 @@ fn resize_cloud_cmd(
         }
     }
 
-    let mut req_resources: Vec<cloud::ops::CloudInstanceResourceRequest> = vec![];
+    let mut req_resources = vec![];
 
     if let Some(compute_size) = compute_size {
-        req_resources.push(cloud::ops::CloudInstanceResourceRequest {
+        req_resources.push(CloudInstanceResourceRequest {
             name: "compute".to_string(),
             value: compute_size.clone(),
         });
@@ -161,7 +162,7 @@ fn resize_cloud_cmd(
     }
 
     if let Some(storage_size) = storage_size {
-        req_resources.push(cloud::ops::CloudInstanceResourceRequest {
+        req_resources.push(CloudInstanceResourceRequest {
             name: "storage".to_string(),
             value: storage_size.clone(),
         });
@@ -189,13 +190,11 @@ fn resize_cloud_cmd(
     }
 
     for res in req_resources {
-        let request = cloud::ops::CloudInstanceResize {
-            name: name.to_string(),
-            org: org_slug.to_string(),
+        let request = CloudInstanceResize {
             requested_resources: Some(vec![res]),
             tier: billables.tier,
         };
-        cloud::ops::resize_cloud_instance(&client, &request)?;
+        cloud::ops::resize_cloud_instance(&client, org_slug, name, request)?;
     }
     msg!("{BRANDING_CLOUD} instance {inst_name} has been resized successfuly.");
     msg!("To connect to the instance run:");

--- a/src/portable/instance/upgrade.rs
+++ b/src/portable/instance/upgrade.rs
@@ -7,6 +7,7 @@ use anyhow::Context;
 use const_format::concatcp;
 use fn_error_context::context;
 use gel_cli_derive::IntoArgs;
+use gel_cli_instance::cloud::CloudInstanceUpgrade;
 
 use crate::branding::{BRANDING, BRANDING_CLI_CMD, BRANDING_CLOUD, QUERY_TAG};
 use crate::cloud;
@@ -314,14 +315,12 @@ pub fn upgrade_cloud(
             available_upgrade: None,
         })
     } else {
-        let request = cloud::ops::CloudInstanceUpgrade {
-            org: org.to_string(),
-            name: name.to_string(),
+        let request = CloudInstanceUpgrade {
             version: target_ver.to_string(),
             force,
         };
 
-        cloud::ops::upgrade_cloud_instance(client, &request)?;
+        cloud::ops::upgrade_cloud_instance(client, org, name, request)?;
 
         Ok(UpgradeResult {
             action: UpgradeAction::Upgraded,

--- a/src/portable/options.rs
+++ b/src/portable/options.rs
@@ -2,9 +2,9 @@ use std::fmt;
 use std::str::FromStr;
 
 use gel_cli_derive::IntoArgs;
+use gel_cli_instance::cloud::CloudTier;
 use gel_tokio::CloudName;
 
-use crate::cloud::ops::CloudTier;
 use crate::process::{self, IntoArg};
 
 #[derive(Clone, Debug)]

--- a/src/portable/project/init.rs
+++ b/src/portable/project/init.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use anyhow::Context;
 use clap::ValueHint;
 use const_format::concatcp;
+use gel_cli_instance::cloud::CloudInstanceCreate;
 use gel_tokio::PROJECT_FILES;
 use rand::{Rng, thread_rng};
 
@@ -439,9 +440,8 @@ fn do_cloud_init(
     options: &Command,
     client: &CloudClient,
 ) -> anyhow::Result<project::ProjectInfo> {
-    let request = crate::cloud::ops::CloudInstanceCreate {
+    let request = CloudInstanceCreate {
         name: name.clone(),
-        org: org.clone(),
         version: version.to_string(),
         region: None,
         tier: None,
@@ -449,7 +449,7 @@ fn do_cloud_init(
         source_instance_id: None,
         source_backup_id: None,
     };
-    crate::cloud::ops::create_cloud_instance(client, &request)?;
+    crate::cloud::ops::create_cloud_instance(client, &org, request)?;
     let full_name = format!("{org}/{name}");
 
     let handle = project::Handle {


### PR DESCRIPTION
The Cloud API HTTP integration was previously scattered throughout the cloud package. This is a first refactoring that extracts the API to a dedicated package that deals with REST resources, routes and clear error messages.

Only one feature is added here: the ability to view cloud instance logs.

Tested by running the various cloud operations by hand but we should be able to add some more extensive testing in a later revision.

Some examples of error conditions:

```
# gel instance create -I asdf/asdf
gel error: Not found: The requested organization with name 'asdf' was not found
```

```
# gel instance destroy -I mmastrac/foo2
Do you really want to delete instance "mmastrac/foo2"? (type `Yes`)
> Yes
gel error: Could not destroy Gel Cloud instance: Not found: The requested instance with name 'mmastrac/foo2' was not found
```

```
# GEL_CLOUD_API_ENDPOINT=http://localhost:56561 gel instance destroy -I mmastrac/foo2
Do you really want to delete instance "mmastrac/foo2"? (type `Yes`)
> Yes
[2025-03-19T22:06:35Z WARN  gel::cloud::client] The server is taking a long time to respond.
gel error: Could not destroy Gel Cloud instance: I/O error while attempting to make an HTTP request: connection refused Connection refused (os error 111)
```

