### PR TITLE
Don't spew stdin for failed docker builds

### DIFF
--- a/tests/common/docker.rs
+++ b/tests/common/docker.rs
@@ -114,12 +114,14 @@ impl Context {
 }
 
 pub fn build_image(context: Context, tagname: &str) -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let path = temp.path().join("Dockerfile");
+    fs::write(&path, context.build()?)?;
     Command::new("docker")
         .arg("build")
-        .arg("-")
+        .arg(path)
         .arg("-t")
         .arg(tagname)
-        .write_stdin(context.build()?)
         .assert()
         .success();
     Ok(())

--- a/tests/common/docker.rs
+++ b/tests/common/docker.rs
@@ -119,9 +119,11 @@ pub fn build_image(context: Context, tagname: &str) -> anyhow::Result<()> {
     fs::write(&path, context.build()?)?;
     Command::new("docker")
         .arg("build")
+        .arg("-f")
         .arg(path)
         .arg("-t")
         .arg(tagname)
+        .arg(temp.path())
         .assert()
         .success();
     Ok(())


### PR DESCRIPTION
When the docker builds failed, they spewed 100k lines to stdout.