### PR TITLE
workflows: Collect all builds before publishing

### DIFF
--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -1,4 +1,4 @@
-<% macro workflow(targets, subdist="") %>
+<% macro workflow(targets, subdist="", publish_all=True) %>
   prep:
     runs-on: ubuntu-latest
     outputs:
@@ -264,10 +264,22 @@
         name: builds-<< tgt.name >>
         path: artifacts/<< plat_id >>
 <% endfor %>
+
+<%- if publish_all %>
+  collect:
+    needs:
+    <%- for tgt in targets.linux + targets.macos + targets.win %>
+    - build-<< tgt.name >>
+    <%- endfor %>
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'All builds passed, ready to publish now!'
+<%- endif %>
+
 <% for tgt in targets.linux %>
 <% set plat_id = tgt.platform + ("{}".format(tgt.platform_libc) if tgt.platform_libc else "") + ("-{}".format(tgt.platform_version) if tgt.platform_version else "") %>
   publish-<< tgt.name >>:
-    needs: [build-<< tgt.name >>]
+    needs: [<% if publish_all %>collect<% else %>build-<< tgt.name >><% endif %>]
     runs-on: ubuntu-latest
 
     steps:
@@ -332,7 +344,7 @@
 <% for tgt in targets.macos %>
 <% set plat_id = tgt.platform + ("{}".format(tgt.platform_libc) if tgt.platform_libc else "") + ("-{}".format(tgt.platform_version) if tgt.platform_version else "") %>
   publish-<< tgt.name >>:
-    needs: [build-<< tgt.name >>]
+    needs: [<% if publish_all %>collect<% else %>build-<< tgt.name >><% endif %>]
     runs-on: ubuntu-latest
 
     steps:
@@ -367,7 +379,7 @@
 <% for tgt in targets.win %>
 <% set plat_id = tgt.platform + ("{}".format(tgt.platform_libc) if tgt.platform_libc else "") + ("-{}".format(tgt.platform_version) if tgt.platform_version else "") %>
   publish-<< tgt.name >>:
-    needs: [build-<< tgt.name >>]
+    needs: [<% if publish_all %>collect<% else %>build-<< tgt.name >><% endif %>]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1357,10 +1357,40 @@ jobs:
         name: builds-win-x86_64
         path: artifacts/win-x86_64
 
+  collect:
+    needs:
+    - build-debian-buster-x86_64
+    - build-debian-buster-aarch64
+    - build-debian-bullseye-x86_64
+    - build-debian-bullseye-aarch64
+    - build-debian-bookworm-x86_64
+    - build-debian-bookworm-aarch64
+    - build-ubuntu-bionic-x86_64
+    - build-ubuntu-bionic-aarch64
+    - build-ubuntu-focal-x86_64
+    - build-ubuntu-focal-aarch64
+    - build-ubuntu-jammy-x86_64
+    - build-ubuntu-jammy-aarch64
+    - build-ubuntu-noble-x86_64
+    - build-ubuntu-noble-aarch64
+    - build-centos-7-x86_64
+    - build-centos-8-x86_64
+    - build-centos-8-aarch64
+    - build-rockylinux-9-x86_64
+    - build-rockylinux-9-aarch64
+    - build-linux-x86_64
+    - build-linux-aarch64
+    - build-macos-x86_64
+    - build-macos-aarch64
+    - build-win-x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'All builds passed, ready to publish now!'
+
 
 
   publish-debian-buster-x86_64:
-    needs: [build-debian-buster-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1418,7 +1448,7 @@ jobs:
 
 
   publish-debian-buster-aarch64:
-    needs: [build-debian-buster-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1476,7 +1506,7 @@ jobs:
 
 
   publish-debian-bullseye-x86_64:
-    needs: [build-debian-bullseye-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1534,7 +1564,7 @@ jobs:
 
 
   publish-debian-bullseye-aarch64:
-    needs: [build-debian-bullseye-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1592,7 +1622,7 @@ jobs:
 
 
   publish-debian-bookworm-x86_64:
-    needs: [build-debian-bookworm-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1650,7 +1680,7 @@ jobs:
 
 
   publish-debian-bookworm-aarch64:
-    needs: [build-debian-bookworm-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1708,7 +1738,7 @@ jobs:
 
 
   publish-ubuntu-bionic-x86_64:
-    needs: [build-ubuntu-bionic-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1766,7 +1796,7 @@ jobs:
 
 
   publish-ubuntu-bionic-aarch64:
-    needs: [build-ubuntu-bionic-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1824,7 +1854,7 @@ jobs:
 
 
   publish-ubuntu-focal-x86_64:
-    needs: [build-ubuntu-focal-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1882,7 +1912,7 @@ jobs:
 
 
   publish-ubuntu-focal-aarch64:
-    needs: [build-ubuntu-focal-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1940,7 +1970,7 @@ jobs:
 
 
   publish-ubuntu-jammy-x86_64:
-    needs: [build-ubuntu-jammy-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1998,7 +2028,7 @@ jobs:
 
 
   publish-ubuntu-jammy-aarch64:
-    needs: [build-ubuntu-jammy-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2056,7 +2086,7 @@ jobs:
 
 
   publish-ubuntu-noble-x86_64:
-    needs: [build-ubuntu-noble-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2114,7 +2144,7 @@ jobs:
 
 
   publish-ubuntu-noble-aarch64:
-    needs: [build-ubuntu-noble-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2172,7 +2202,7 @@ jobs:
 
 
   publish-centos-7-x86_64:
-    needs: [build-centos-7-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2230,7 +2260,7 @@ jobs:
 
 
   publish-centos-8-x86_64:
-    needs: [build-centos-8-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2288,7 +2318,7 @@ jobs:
 
 
   publish-centos-8-aarch64:
-    needs: [build-centos-8-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2346,7 +2376,7 @@ jobs:
 
 
   publish-rockylinux-9-x86_64:
-    needs: [build-rockylinux-9-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2404,7 +2434,7 @@ jobs:
 
 
   publish-rockylinux-9-aarch64:
-    needs: [build-rockylinux-9-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2462,7 +2492,7 @@ jobs:
 
 
   publish-linux-x86_64:
-    needs: [build-linux-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2522,7 +2552,7 @@ jobs:
 
 
   publish-linux-aarch64:
-    needs: [build-linux-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2583,7 +2613,7 @@ jobs:
 
 
   publish-macos-x86_64:
-    needs: [build-macos-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2615,7 +2645,7 @@ jobs:
 
 
   publish-macos-aarch64:
-    needs: [build-macos-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2648,7 +2678,7 @@ jobs:
 
 
   publish-win-x86_64:
-    needs: [build-win-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -891,10 +891,40 @@ jobs:
         name: builds-win-x86_64
         path: artifacts/win-x86_64
 
+  collect:
+    needs:
+    - build-debian-buster-x86_64
+    - build-debian-buster-aarch64
+    - build-debian-bullseye-x86_64
+    - build-debian-bullseye-aarch64
+    - build-debian-bookworm-x86_64
+    - build-debian-bookworm-aarch64
+    - build-ubuntu-bionic-x86_64
+    - build-ubuntu-bionic-aarch64
+    - build-ubuntu-focal-x86_64
+    - build-ubuntu-focal-aarch64
+    - build-ubuntu-jammy-x86_64
+    - build-ubuntu-jammy-aarch64
+    - build-ubuntu-noble-x86_64
+    - build-ubuntu-noble-aarch64
+    - build-centos-7-x86_64
+    - build-centos-8-x86_64
+    - build-centos-8-aarch64
+    - build-rockylinux-9-x86_64
+    - build-rockylinux-9-aarch64
+    - build-linux-x86_64
+    - build-linux-aarch64
+    - build-macos-x86_64
+    - build-macos-aarch64
+    - build-win-x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'All builds passed, ready to publish now!'
+
 
 
   publish-debian-buster-x86_64:
-    needs: [build-debian-buster-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -950,7 +980,7 @@ jobs:
 
 
   publish-debian-buster-aarch64:
-    needs: [build-debian-buster-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1006,7 +1036,7 @@ jobs:
 
 
   publish-debian-bullseye-x86_64:
-    needs: [build-debian-bullseye-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1062,7 +1092,7 @@ jobs:
 
 
   publish-debian-bullseye-aarch64:
-    needs: [build-debian-bullseye-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1118,7 +1148,7 @@ jobs:
 
 
   publish-debian-bookworm-x86_64:
-    needs: [build-debian-bookworm-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1174,7 +1204,7 @@ jobs:
 
 
   publish-debian-bookworm-aarch64:
-    needs: [build-debian-bookworm-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1230,7 +1260,7 @@ jobs:
 
 
   publish-ubuntu-bionic-x86_64:
-    needs: [build-ubuntu-bionic-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1286,7 +1316,7 @@ jobs:
 
 
   publish-ubuntu-bionic-aarch64:
-    needs: [build-ubuntu-bionic-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1342,7 +1372,7 @@ jobs:
 
 
   publish-ubuntu-focal-x86_64:
-    needs: [build-ubuntu-focal-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1398,7 +1428,7 @@ jobs:
 
 
   publish-ubuntu-focal-aarch64:
-    needs: [build-ubuntu-focal-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1454,7 +1484,7 @@ jobs:
 
 
   publish-ubuntu-jammy-x86_64:
-    needs: [build-ubuntu-jammy-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1510,7 +1540,7 @@ jobs:
 
 
   publish-ubuntu-jammy-aarch64:
-    needs: [build-ubuntu-jammy-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1566,7 +1596,7 @@ jobs:
 
 
   publish-ubuntu-noble-x86_64:
-    needs: [build-ubuntu-noble-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1622,7 +1652,7 @@ jobs:
 
 
   publish-ubuntu-noble-aarch64:
-    needs: [build-ubuntu-noble-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1678,7 +1708,7 @@ jobs:
 
 
   publish-centos-7-x86_64:
-    needs: [build-centos-7-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1734,7 +1764,7 @@ jobs:
 
 
   publish-centos-8-x86_64:
-    needs: [build-centos-8-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1790,7 +1820,7 @@ jobs:
 
 
   publish-centos-8-aarch64:
-    needs: [build-centos-8-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1846,7 +1876,7 @@ jobs:
 
 
   publish-rockylinux-9-x86_64:
-    needs: [build-rockylinux-9-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1902,7 +1932,7 @@ jobs:
 
 
   publish-rockylinux-9-aarch64:
-    needs: [build-rockylinux-9-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1958,7 +1988,7 @@ jobs:
 
 
   publish-linux-x86_64:
-    needs: [build-linux-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2016,7 +2046,7 @@ jobs:
 
 
   publish-linux-aarch64:
-    needs: [build-linux-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2075,7 +2105,7 @@ jobs:
 
 
   publish-macos-x86_64:
-    needs: [build-macos-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2106,7 +2136,7 @@ jobs:
 
 
   publish-macos-aarch64:
-    needs: [build-macos-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2138,7 +2168,7 @@ jobs:
 
 
   publish-win-x86_64:
-    needs: [build-win-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -915,10 +915,40 @@ jobs:
         name: builds-win-x86_64
         path: artifacts/win-x86_64
 
+  collect:
+    needs:
+    - build-debian-buster-x86_64
+    - build-debian-buster-aarch64
+    - build-debian-bullseye-x86_64
+    - build-debian-bullseye-aarch64
+    - build-debian-bookworm-x86_64
+    - build-debian-bookworm-aarch64
+    - build-ubuntu-bionic-x86_64
+    - build-ubuntu-bionic-aarch64
+    - build-ubuntu-focal-x86_64
+    - build-ubuntu-focal-aarch64
+    - build-ubuntu-jammy-x86_64
+    - build-ubuntu-jammy-aarch64
+    - build-ubuntu-noble-x86_64
+    - build-ubuntu-noble-aarch64
+    - build-centos-7-x86_64
+    - build-centos-8-x86_64
+    - build-centos-8-aarch64
+    - build-rockylinux-9-x86_64
+    - build-rockylinux-9-aarch64
+    - build-linux-x86_64
+    - build-linux-aarch64
+    - build-macos-x86_64
+    - build-macos-aarch64
+    - build-win-x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'All builds passed, ready to publish now!'
+
 
 
   publish-debian-buster-x86_64:
-    needs: [build-debian-buster-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -976,7 +1006,7 @@ jobs:
 
 
   publish-debian-buster-aarch64:
-    needs: [build-debian-buster-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1034,7 +1064,7 @@ jobs:
 
 
   publish-debian-bullseye-x86_64:
-    needs: [build-debian-bullseye-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1092,7 +1122,7 @@ jobs:
 
 
   publish-debian-bullseye-aarch64:
-    needs: [build-debian-bullseye-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1150,7 +1180,7 @@ jobs:
 
 
   publish-debian-bookworm-x86_64:
-    needs: [build-debian-bookworm-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1208,7 +1238,7 @@ jobs:
 
 
   publish-debian-bookworm-aarch64:
-    needs: [build-debian-bookworm-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1266,7 +1296,7 @@ jobs:
 
 
   publish-ubuntu-bionic-x86_64:
-    needs: [build-ubuntu-bionic-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1324,7 +1354,7 @@ jobs:
 
 
   publish-ubuntu-bionic-aarch64:
-    needs: [build-ubuntu-bionic-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1382,7 +1412,7 @@ jobs:
 
 
   publish-ubuntu-focal-x86_64:
-    needs: [build-ubuntu-focal-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1440,7 +1470,7 @@ jobs:
 
 
   publish-ubuntu-focal-aarch64:
-    needs: [build-ubuntu-focal-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1498,7 +1528,7 @@ jobs:
 
 
   publish-ubuntu-jammy-x86_64:
-    needs: [build-ubuntu-jammy-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1556,7 +1586,7 @@ jobs:
 
 
   publish-ubuntu-jammy-aarch64:
-    needs: [build-ubuntu-jammy-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1614,7 +1644,7 @@ jobs:
 
 
   publish-ubuntu-noble-x86_64:
-    needs: [build-ubuntu-noble-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1672,7 +1702,7 @@ jobs:
 
 
   publish-ubuntu-noble-aarch64:
-    needs: [build-ubuntu-noble-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1730,7 +1760,7 @@ jobs:
 
 
   publish-centos-7-x86_64:
-    needs: [build-centos-7-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1788,7 +1818,7 @@ jobs:
 
 
   publish-centos-8-x86_64:
-    needs: [build-centos-8-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1846,7 +1876,7 @@ jobs:
 
 
   publish-centos-8-aarch64:
-    needs: [build-centos-8-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1904,7 +1934,7 @@ jobs:
 
 
   publish-rockylinux-9-x86_64:
-    needs: [build-rockylinux-9-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -1962,7 +1992,7 @@ jobs:
 
 
   publish-rockylinux-9-aarch64:
-    needs: [build-rockylinux-9-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2020,7 +2050,7 @@ jobs:
 
 
   publish-linux-x86_64:
-    needs: [build-linux-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2080,7 +2110,7 @@ jobs:
 
 
   publish-linux-aarch64:
-    needs: [build-linux-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2141,7 +2171,7 @@ jobs:
 
 
   publish-macos-x86_64:
-    needs: [build-macos-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2173,7 +2203,7 @@ jobs:
 
 
   publish-macos-aarch64:
-    needs: [build-macos-aarch64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:
@@ -2206,7 +2236,7 @@ jobs:
 
 
   publish-win-x86_64:
-    needs: [build-win-x86_64]
+    needs: [collect]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Various pieces of CI and infra are generally unhappy when CLI releases
drift across targets, so prevent that from happening.
