### PR TITLE
Support branching commands on cloud without a project

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -24,9 +24,6 @@
     "edgedb": {
       "inputs": {
         "crane": "crane",
-        "fenix": [
-          "fenix"
-        ],
         "flake-parts": [
           "flake-parts"
         ],
@@ -35,11 +32,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739189006,
-        "narHash": "sha256-d79oc7VXVB5rQ2vhtAy9sGHW4vXRvicwsAjm8T1zAXA=",
+        "lastModified": 1740414402,
+        "narHash": "sha256-UWzHqJLq8zfwrFEw+O3iFQTUEHMmKNxu6lyk3Hphi9c=",
         "owner": "edgedb",
         "repo": "packages-nix",
-        "rev": "fe563c974e14282bf8206e720a033dc7ca5521e3",
+        "rev": "d469ff4b8f3f64a1a446cfcfb5414d2fa7c0e844",
         "type": "github"
       },
       "original": {
@@ -56,11 +53,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1739169164,
-        "narHash": "sha256-2+/6/2rHsMjlrulkrjZbwthCQiQpeW2pukRFaaUMLy8=",
+        "lastModified": 1742452566,
+        "narHash": "sha256-sVuLDQ2UIWfXUBbctzrZrXM2X05YjX08K7XHMztt36E=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "d7616af878cd0cb7f940b470440347920395be0c",
+        "rev": "7d9ba794daf5e8cc7ee728859bc688d8e26d5f06",
         "type": "github"
       },
       "original": {
@@ -74,11 +71,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1738453229,
-        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -89,11 +86,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739188797,
-        "narHash": "sha256-3B9J+YAVkj90jEtkGOWM84KrFN9jPcDsmoQDyxTOVxU=",
+        "lastModified": 1743601945,
+        "narHash": "sha256-ZBkvD/Iqx8wKeOirnIbczCj6cxuXFVsmKZ0SeZ1vdfU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0fe418f71717754bd9a57956ee54d5d437c9479e",
+        "rev": "155d1c0aa91f1e7a11693ee96e385bbea87a5a65",
         "type": "github"
       },
       "original": {
@@ -104,14 +101,17 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1738452942,
-        "narHash": "sha256-vJzFZGaCpnmo7I6i416HaBLpC+hvcURh/BQwROcGIp8=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,33 +19,53 @@
     };
   };
 
-  outputs = inputs@{ flake-parts, fenix, edgedb, ... }:
+  outputs =
+    inputs@{
+      flake-parts,
+      fenix,
+      edgedb,
+      ...
+    }:
     flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-      perSystem = { config, system, pkgs, ... }:
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      perSystem =
+        {
+          config,
+          system,
+          pkgs,
+          ...
+        }:
         let
           fenix_pkgs = fenix.packages.${system};
 
-          common = [
-            # needed for running tests
-            edgedb.packages.${system}.edgedb-server-nightly
-          ] ++ pkgs.lib.optional pkgs.stdenv.isDarwin [
-            pkgs.libiconv
-            pkgs.darwin.apple_sdk.frameworks.CoreServices
-            pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
-          ];
+          common =
+            [
+              # needed for running tests
+              edgedb.packages.${system}.edgedb-server-nightly
+            ]
+            ++ pkgs.lib.optional pkgs.stdenv.isDarwin [
+              pkgs.libiconv
+              pkgs.darwin.apple_sdk.frameworks.CoreServices
+              pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+            ];
 
-        in {
+        in
+        {
           devShells.default = pkgs.mkShell {
             buildInputs = common ++ [
               (fenix_pkgs.combine [
                 (fenix_pkgs.fromToolchainFile {
                   file = ./rust-toolchain.toml;
-                  sha256 = "sha256-VZZnlyP69+Y3crrLHQyJirqlHrTtGTsyiSnZB8jEvVo=";
+                  sha256 = "sha256-Hn2uaQzRLidAWpfmRwSRdImifGUCAb9HeAqTYFXWeQk=";
                 })
                 (fenix_pkgs.targets.x86_64-unknown-linux-musl.fromToolchainFile {
                   file = ./rust-toolchain.toml;
-                  sha256 = "sha256-VZZnlyP69+Y3crrLHQyJirqlHrTtGTsyiSnZB8jEvVo=";
+                  sha256 = "sha256-Hn2uaQzRLidAWpfmRwSRdImifGUCAb9HeAqTYFXWeQk=";
                 })
               ])
             ];

--- a/src/branch/context.rs
+++ b/src/branch/context.rs
@@ -1,6 +1,7 @@
 use crate::branding::BRANDING_CLOUD;
 use crate::connect::Connection;
 use crate::credentials;
+use crate::hint::HintExt;
 use crate::platform::tmp_file_path;
 use crate::portable::options::InstanceName;
 use crate::portable::project::{self, get_stash_path};
@@ -29,10 +30,13 @@ pub struct Context {
 }
 
 impl Context {
-    pub async fn new(instance_arg: Option<&InstanceName>) -> anyhow::Result<Context> {
+    pub async fn new(
+        instance_arg: Option<&InstanceName>,
+        branch_arg: Option<&str>,
+    ) -> anyhow::Result<Context> {
         let mut ctx = Context {
             instance_name: None,
-            current_branch: None,
+            current_branch: branch_arg.map(|x| x.to_string()),
             project: None,
             project_ctx_cache: Mutex::new(None),
         };
@@ -40,12 +44,14 @@ impl Context {
         // use instance name provided with --instance
         ctx.instance_name = instance_arg.cloned();
         if let Some(instance_name) = &ctx.instance_name {
-            let instance_name = ensure_local_instance(instance_name)?;
+            if ctx.current_branch.is_none() {
+                let instance_name = ensure_local_instance(instance_name)?;
 
-            let credentials_path = credentials::path(instance_name)?;
-            if credentials_path.exists() {
-                let credentials = credentials::read(&credentials_path).await?;
-                ctx.current_branch = credentials.branch.or(credentials.database);
+                let credentials_path = credentials::path(instance_name)?;
+                if credentials_path.exists() {
+                    let credentials = credentials::read(&credentials_path).await?;
+                    ctx.current_branch = credentials.branch.or(credentials.database);
+                }
             }
             return Ok(ctx);
         }
@@ -55,7 +61,9 @@ impl Context {
         if let Some(location) = &ctx.project {
             let stash_dir = get_stash_path(&location.root)?;
             ctx.instance_name = project::instance_name(&stash_dir).ok();
-            ctx.current_branch = project::database_name(&stash_dir).ok().flatten();
+            if ctx.current_branch.is_none() {
+                ctx.current_branch = project::database_name(&stash_dir).ok().flatten();
+            }
         }
 
         Ok(ctx)
@@ -132,8 +140,8 @@ fn ensure_local_instance(instance_name: &InstanceName) -> anyhow::Result<&str> {
         InstanceName::Cloud { .. } => {
             // should never occur because of the above check
             Err(anyhow::anyhow!(
-                "cannot use branches on {BRANDING_CLOUD} instance unless linked to a project"
-            ))
+                "Missing --branch argument"
+            ).with_hint(|| format!("When using {BRANDING_CLOUD} instance either an explict --branch or a linked project is required.")).into())
         }
     }
 }

--- a/src/branch/mod.rs
+++ b/src/branch/mod.rs
@@ -20,7 +20,8 @@ pub async fn run(
     options: &Options,
     conn: Option<&mut Connection>,
 ) -> anyhow::Result<CommandResult> {
-    let context = context::Context::new(options.instance_name.as_ref()).await?;
+    let context =
+        context::Context::new(options.instance_name.as_ref(), options.branch.as_deref()).await?;
 
     let mut connector: Connector = options.conn_params.clone();
 

--- a/src/commands/backslash.rs
+++ b/src/commands/backslash.rs
@@ -584,6 +584,7 @@ pub async fn execute(
         styler: Some(Styler::new()),
         conn_params: prompt.conn_params.clone(),
         instance_name: None,
+        branch: None,
     };
     options.infer_instance_name()?;
     match cmd {

--- a/src/commands/cli.rs
+++ b/src/commands/cli.rs
@@ -89,6 +89,7 @@ fn init_command_opts(options: &Options) -> Result<commands::Options, anyhow::Err
             None
         },
         instance_name: options.conn_options.instance_opts.maybe_instance(),
+        branch: options.conn_options.branch.clone(),
         conn_params: options.block_on_create_connector()?,
     })
 }

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -82,7 +82,7 @@ pub async fn wipe(connection: &mut Connection, cmd: &WipeDatabase) -> Result<(),
     }
 
     let context =
-        crate::branch::context::Context::new(cmd.instance_opts.maybe_instance().as_ref()).await?;
+        crate::branch::context::Context::new(cmd.instance_opts.maybe_instance().as_ref(), cmd.branch.as_deref()).await?;
     crate::branch::wipe::do_wipe(connection, &context).await?;
     Ok(())
 }

--- a/src/commands/options.rs
+++ b/src/commands/options.rs
@@ -9,16 +9,17 @@ pub struct Options {
     pub styler: Option<Styler>,
     pub conn_params: Connector,
     pub instance_name: Option<portable::options::InstanceName>,
+    pub branch: Option<String>,
 }
 
 impl Options {
     pub fn infer_instance_name(&mut self) -> anyhow::Result<()> {
-        self.instance_name = self
-            .conn_params
-            .get()?
+        let config = &self.conn_params.get()?;
+        self.instance_name = config
             .instance_name()
             .map(|x| portable::options::InstanceName::from_str(&x.to_string()))
             .transpose()?;
+        self.branch = config.branch().map(|x| x.to_string());
         Ok(())
     }
 }

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -304,6 +304,9 @@ pub struct WipeDatabase {
 
     #[command(flatten)]
     pub instance_opts: InstanceOptions,
+
+    #[arg(from_global)]
+    pub branch: Option<String>,
 }
 
 #[derive(clap::Args, Clone, Debug)]

--- a/src/portable/instance/upgrade.rs
+++ b/src/portable/instance/upgrade.rs
@@ -491,6 +491,7 @@ pub async fn dump_instance(inst: &InstanceInfo, destination: &Path) -> anyhow::R
         styler: None,
         conn_params: Connector::new(Ok(config)),
         instance_name: Some(InstanceName::Local(inst.name.clone())),
+        branch: None,
     };
     commands::dump_all(
         &mut cli,
@@ -579,6 +580,7 @@ async fn restore_instance(inst: &InstanceInfo, path: &Path) -> anyhow::Result<()
         styler: None,
         conn_params: Connector::new(Ok(cfg)),
         instance_name: Some(InstanceName::Local(inst.name.clone())),
+        branch: None,
     };
     commands::restore_all(
         &mut cli,

--- a/src/portable/project/init.rs
+++ b/src/portable/project/init.rs
@@ -1255,6 +1255,7 @@ async fn migrate_async(inst: &project::Handle<'_>, ask_for_running: bool) -> any
             styler: None,
             conn_params: Connector::new(inst.get_builder()?.build().map_err(Into::into)),
             instance_name: Some(InstanceName::Local(inst.name.clone())),
+            branch: inst.database.clone(),
         },
     )
     .await?;


### PR DESCRIPTION
Branching commands all need to know the "current branch".
Current branch is either inferred from the project or
read from credentials.json.

This is a problem for cloud instances, becuase they do not
have a credentials.json so before this PR, we only supported
branching commands on cloud if there was an associated project.

This PR makes branching commands use --branch arg to override
current branch, which then removes the need for instances to have
credentials.json.
