### PR TITLE
Update rust toolchain

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -24,9 +24,6 @@
     "edgedb": {
       "inputs": {
         "crane": "crane",
-        "fenix": [
-          "fenix"
-        ],
         "flake-parts": [
           "flake-parts"
         ],
@@ -35,11 +32,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739189006,
-        "narHash": "sha256-d79oc7VXVB5rQ2vhtAy9sGHW4vXRvicwsAjm8T1zAXA=",
+        "lastModified": 1740414402,
+        "narHash": "sha256-UWzHqJLq8zfwrFEw+O3iFQTUEHMmKNxu6lyk3Hphi9c=",
         "owner": "edgedb",
         "repo": "packages-nix",
-        "rev": "fe563c974e14282bf8206e720a033dc7ca5521e3",
+        "rev": "d469ff4b8f3f64a1a446cfcfb5414d2fa7c0e844",
         "type": "github"
       },
       "original": {
@@ -56,11 +53,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1739169164,
-        "narHash": "sha256-2+/6/2rHsMjlrulkrjZbwthCQiQpeW2pukRFaaUMLy8=",
+        "lastModified": 1742452566,
+        "narHash": "sha256-sVuLDQ2UIWfXUBbctzrZrXM2X05YjX08K7XHMztt36E=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "d7616af878cd0cb7f940b470440347920395be0c",
+        "rev": "7d9ba794daf5e8cc7ee728859bc688d8e26d5f06",
         "type": "github"
       },
       "original": {
@@ -74,11 +71,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1738453229,
-        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -89,11 +86,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739188797,
-        "narHash": "sha256-3B9J+YAVkj90jEtkGOWM84KrFN9jPcDsmoQDyxTOVxU=",
+        "lastModified": 1743601945,
+        "narHash": "sha256-ZBkvD/Iqx8wKeOirnIbczCj6cxuXFVsmKZ0SeZ1vdfU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0fe418f71717754bd9a57956ee54d5d437c9479e",
+        "rev": "155d1c0aa91f1e7a11693ee96e385bbea87a5a65",
         "type": "github"
       },
       "original": {
@@ -104,14 +101,17 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1738452942,
-        "narHash": "sha256-vJzFZGaCpnmo7I6i416HaBLpC+hvcURh/BQwROcGIp8=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,33 +19,53 @@
     };
   };
 
-  outputs = inputs@{ flake-parts, fenix, edgedb, ... }:
+  outputs =
+    inputs@{
+      flake-parts,
+      fenix,
+      edgedb,
+      ...
+    }:
     flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-      perSystem = { config, system, pkgs, ... }:
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      perSystem =
+        {
+          config,
+          system,
+          pkgs,
+          ...
+        }:
         let
           fenix_pkgs = fenix.packages.${system};
 
-          common = [
-            # needed for running tests
-            edgedb.packages.${system}.edgedb-server-nightly
-          ] ++ pkgs.lib.optional pkgs.stdenv.isDarwin [
-            pkgs.libiconv
-            pkgs.darwin.apple_sdk.frameworks.CoreServices
-            pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
-          ];
+          common =
+            [
+              # needed for running tests
+              edgedb.packages.${system}.edgedb-server-nightly
+            ]
+            ++ pkgs.lib.optional pkgs.stdenv.isDarwin [
+              pkgs.libiconv
+              pkgs.darwin.apple_sdk.frameworks.CoreServices
+              pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+            ];
 
-        in {
+        in
+        {
           devShells.default = pkgs.mkShell {
             buildInputs = common ++ [
               (fenix_pkgs.combine [
                 (fenix_pkgs.fromToolchainFile {
                   file = ./rust-toolchain.toml;
-                  sha256 = "sha256-VZZnlyP69+Y3crrLHQyJirqlHrTtGTsyiSnZB8jEvVo=";
+                  sha256 = "sha256-Hn2uaQzRLidAWpfmRwSRdImifGUCAb9HeAqTYFXWeQk=";
                 })
                 (fenix_pkgs.targets.x86_64-unknown-linux-musl.fromToolchainFile {
                   file = ./rust-toolchain.toml;
-                  sha256 = "sha256-VZZnlyP69+Y3crrLHQyJirqlHrTtGTsyiSnZB8jEvVo=";
+                  sha256 = "sha256-Hn2uaQzRLidAWpfmRwSRdImifGUCAb9HeAqTYFXWeQk=";
                 })
               ])
             ];

--- a/gel-cli-instance/src/cloud/mod.rs
+++ b/gel-cli-instance/src/cloud/mod.rs
@@ -236,7 +236,7 @@ impl<H: CloudHttp> CloudApi<H> {
             .post(
                 CloudResource::Instance(org_slug, name),
                 &self.endpoint(&format!("orgs/{org_slug}/instances/{name}/backups")),
-                {},
+                (),
             )
             .await
     }
@@ -278,7 +278,7 @@ impl<H: CloudHttp> CloudApi<H> {
             .post(
                 CloudResource::Instance(org_slug, name),
                 &self.endpoint(&format!("orgs/{org_slug}/instances/{name}/restart")),
-                {},
+                (),
             )
             .await
     }

--- a/src/cloud/client.rs
+++ b/src/cloud/client.rs
@@ -57,7 +57,7 @@ impl Http {
         });
         let resp = req.send().await;
         slow_task_warning.abort();
-        let resp = resp.map_err(|e| Http::map_error(e))?;
+        let resp = resp.map_err(Http::map_error)?;
 
         let status = resp.status();
         debug!("Got response: status: {:?}", status);
@@ -83,9 +83,7 @@ impl Http {
 
             let message = if let Ok(body) = serde_json::from_str::<ErrorResponse>(&body) {
                 body.error
-            } else {
-                if body.is_empty() { None } else { Some(body) }
-            };
+            } else if body.is_empty() { None } else { Some(body) };
 
             match status {
                 reqwest::StatusCode::BAD_REQUEST => {

--- a/src/cloud/client.rs
+++ b/src/cloud/client.rs
@@ -83,7 +83,11 @@ impl Http {
 
             let message = if let Ok(body) = serde_json::from_str::<ErrorResponse>(&body) {
                 body.error
-            } else if body.is_empty() { None } else { Some(body) };
+            } else if body.is_empty() {
+                None
+            } else {
+                Some(body)
+            };
 
             match status {
                 reqwest::StatusCode::BAD_REQUEST => {

--- a/src/commands/list_casts.rs
+++ b/src/commands/list_casts.rs
@@ -16,7 +16,7 @@ struct Cast {
     volatility_str: String,
 }
 
-pub async fn list_casts<'x>(
+pub async fn list_casts(
     cli: &mut Connection,
     options: &Options,
     pattern: &Option<String>,

--- a/src/commands/list_roles.rs
+++ b/src/commands/list_roles.rs
@@ -3,7 +3,7 @@ use crate::commands::filter;
 use crate::commands::list;
 use crate::connect::Connection;
 
-pub async fn list_roles<'x>(
+pub async fn list_roles(
     cli: &mut Connection,
     options: &Options,
     pattern: &Option<String>,

--- a/src/commands/list_scalar_types.rs
+++ b/src/commands/list_scalar_types.rs
@@ -16,7 +16,7 @@ struct ScalarType {
     kind: String,
 }
 
-pub async fn list_scalar_types<'x>(
+pub async fn list_scalar_types(
     cli: &mut Connection,
     options: &Options,
     pattern: &Option<String>,

--- a/src/commands/psql.rs
+++ b/src/commands/psql.rs
@@ -12,7 +12,7 @@ use crate::commands::Options;
 use crate::interrupt;
 use crate::print;
 
-pub async fn psql<'x>(cli: &mut Connection, _options: &Options) -> Result<(), anyhow::Error> {
+pub async fn psql(cli: &mut Connection, _options: &Options) -> Result<(), anyhow::Error> {
     let mut cmd = Command::new("psql");
     let path = if let Some(dir) = option_env!("PSQL_DEFAULT_PATH") {
         let psql_path = Path::new(dir).join("psql");

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -221,7 +221,7 @@ async fn is_non_empty_db(cli: &mut Connection) -> Result<bool, anyhow::Error> {
     return Ok(non_empty);
 }
 
-pub async fn restore<'x>(
+pub async fn restore(
     cli: &mut Connection,
     options: &Options,
     params: &RestoreCmd,
@@ -233,7 +233,7 @@ pub async fn restore<'x>(
     }
 }
 
-async fn restore_db<'x>(
+async fn restore_db(
     cli: &mut Connection,
     _options: &Options,
     params: &RestoreCmd,
@@ -327,7 +327,7 @@ async fn apply_init(cli: &mut Connection, path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn restore_all<'x>(
+pub async fn restore_all(
     cli: &mut Connection,
     options: &Options,
     params: &RestoreCmd,

--- a/src/portable/instance/credentials.rs
+++ b/src/portable/instance/credentials.rs
@@ -56,7 +56,7 @@ pub fn show_credentials(options: &Options, c: &Command) -> anyhow::Result<()> {
     } else if c.insecure_dsn {
         creds.dsn_url()
     } else {
-        crate::table::settings(&credentials_table(&creds));
+        crate::table::settings(&credentials_table(creds));
         None
     } {
         stdout()


### PR DESCRIPTION
Updates nix env that provides rust toolchain.
Apparently, we have already bumped rust-toolchain.toml
and edition used to 2024.

Also applies new clippy lints and fmt.
