### PR TITLE
Improve credential load/save handing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,7 +1511,6 @@ dependencies = [
  "gel-cli-derive",
  "gel-cli-instance",
  "gel-derive",
- "gel-dsn",
  "gel-errors",
  "gel-jwt",
  "gel-protocol",
@@ -1639,9 +1638,15 @@ dependencies = [
 
 [[package]]
 name = "gel-dsn"
+<<<<<<< HEAD
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "299df7202234e7e15016fa6bcc9c3647dd14f58713472dd88fcaf44ddc80b30f"
+=======
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1104cd7b44da2116b86eadcbacf140a898635d46fcd7b5e0d5243c658087e3"
+>>>>>>> 842175e (.)
 dependencies = [
  "base64 0.22.1",
  "crc16",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,15 +1638,9 @@ dependencies = [
 
 [[package]]
 name = "gel-dsn"
-<<<<<<< HEAD
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "299df7202234e7e15016fa6bcc9c3647dd14f58713472dd88fcaf44ddc80b30f"
-=======
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1104cd7b44da2116b86eadcbacf140a898635d46fcd7b5e0d5243c658087e3"
->>>>>>> 842175e (.)
 dependencies = [
  "base64 0.22.1",
  "crc16",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ gel-derive = { version = "0.7" }
 gel-errors = { version = "0.5" }
 gel-auth = { version = "0.1" }
 gel-tokio = { version = "0.10", features=["admin_socket", "unstable"] }
-gel-dsn = { version = "0.2", features = ["unstable", "gel", "auto-log-trace", "auto-log-warning"] }
+gel-dsn = { version = "0.2" }
 gel-jwt = { version = "0.1", features = ["gel"] }
 
 [package]
@@ -54,7 +54,6 @@ gel-derive = { workspace = true }
 gel-errors = { workspace = true }
 gel-auth = { workspace = true }
 gel-tokio = { workspace = true }
-gel-dsn = { workspace = true }
 gel-jwt = { workspace = true }
 
 gel-cli-instance = { path = "./gel-cli-instance" }

--- a/src/branch/context.rs
+++ b/src/branch/context.rs
@@ -1,9 +1,9 @@
 use gel_tokio::InstanceName;
+use gel_tokio::dsn::DatabaseBranch;
+use log::warn;
 
-use crate::branding::BRANDING_CLOUD;
 use crate::connect::Connection;
 use crate::credentials;
-use crate::hint::HintExt;
 use crate::platform::tmp_file_path;
 use crate::portable::project::{self, get_stash_path};
 use std::fs;
@@ -28,7 +28,7 @@ pub struct Context {
     ///   - the project has no linked instance.
     ///
     ///   This happens when we supply just a URL, for example.
-    current_branch: Option<String>,
+    current_branch: DatabaseBranch,
 
     /// Project manifest cache
     project_ctx_cache: Mutex<Option<project::Context>>,
@@ -38,7 +38,7 @@ impl Context {
     pub async fn new(instance_arg: Option<&InstanceName>) -> anyhow::Result<Context> {
         let mut ctx = Context {
             instance_name: None,
-            current_branch: None,
+            current_branch: DatabaseBranch::Default,
             project: None,
             project_ctx_cache: Mutex::new(None),
         };
@@ -48,13 +48,21 @@ impl Context {
             ctx.instance_name = Some(instance_name.clone());
 
             match instance_name {
-                InstanceName::Local(instance_name) => {
+                InstanceName::Local(_) => {
                     // non-cloud instances have branch written in credentials.json
-
-                    let credentials_path = credentials::path(instance_name)?;
-                    if credentials_path.exists() {
-                        let credentials = credentials::read(&credentials_path).await?;
-                        ctx.current_branch = credentials.branch.or(credentials.database);
+                    if let Some(credentials) = credentials::read(&instance_name)? {
+                        match (credentials.branch, credentials.database) {
+                            (Some(branch), Some(_)) => {
+                                ctx.current_branch = DatabaseBranch::Ambiguous(branch)
+                            }
+                            (Some(branch), None) => {
+                                ctx.current_branch = DatabaseBranch::Branch(branch)
+                            }
+                            (None, Some(database)) => {
+                                ctx.current_branch = DatabaseBranch::Database(database)
+                            }
+                            (None, None) => ctx.current_branch = DatabaseBranch::Default,
+                        }
                     }
                 }
                 InstanceName::Cloud { .. } => {
@@ -70,7 +78,8 @@ impl Context {
         if let Some(location) = &ctx.project {
             let stash_dir = get_stash_path(&location.root)?;
             ctx.instance_name = project::instance_name(&stash_dir).ok();
-            ctx.current_branch = project::database_name(&stash_dir).ok().flatten();
+            ctx.current_branch =
+                project::database_name(&stash_dir).unwrap_or(DatabaseBranch::Default);
         }
 
         Ok(ctx)
@@ -79,8 +88,8 @@ impl Context {
     /// Returns the "current" branch or branch of the connection.
     /// Connection must not have its branch param modified.
     pub async fn get_current_branch(&self, connection: &mut Connection) -> anyhow::Result<String> {
-        if let Some(b) = &self.current_branch {
-            return Ok(b.clone());
+        if let Some(b) = &self.current_branch.name() {
+            return Ok(b.to_string());
         }
 
         // if the instance is unknown, current branch is just "the branch of the connection"
@@ -100,11 +109,7 @@ impl Context {
     }
 
     pub async fn update_current_branch(&self, branch: &str) -> anyhow::Result<()> {
-        let Some(instance_name) = &self.instance_name else {
-            return Ok(());
-        };
-
-        // if we are in a project, update the stash/database
+        // If we are in a project, update the stash/database
         if let Some(project) = &self.project {
             let stash_path = get_stash_path(&project.root)?.join("database");
 
@@ -112,17 +117,19 @@ impl Context {
             let tmp = tmp_file_path(&stash_path);
             fs::write(&tmp, branch)?;
             fs::rename(&tmp, &stash_path)?;
-        } else {
-            // otherwise, update credentials.json
-            let name = ensure_local_instance(instance_name)?;
-
-            let path = credentials::path(name)?;
-            let mut credentials = credentials::read(&path).await?;
-            credentials.database = Some(branch.to_string());
-            credentials.branch = Some(branch.to_string());
-
-            credentials::write_async(&path, &credentials).await?;
         }
+
+        // If we have a local instance, also update the credentials.
+        if let Some(x @ InstanceName::Local(_)) = &self.instance_name {
+            if let Some(mut credentials) = credentials::read(&x)? {
+                credentials.database = Some(branch.to_string());
+                credentials.branch = Some(branch.to_string());
+                credentials::write(&x, &credentials)?;
+            } else {
+                warn!("Credentials unexpectedly missing for {:#}", x);
+            }
+        }
+
         Ok(())
     }
 
@@ -139,16 +146,5 @@ impl Context {
         let mut cache_lock = self.project_ctx_cache.lock().unwrap();
         *cache_lock = Some(ctx.clone());
         Ok(Some(ctx))
-    }
-}
-
-fn ensure_local_instance(instance_name: &InstanceName) -> anyhow::Result<&str> {
-    match instance_name {
-        InstanceName::Local(instance) => Ok(instance),
-        InstanceName::Cloud { .. } => Err(anyhow::anyhow!(
-            "cannot set a current branch on {BRANDING_CLOUD} instance"
-        )
-        .hint("current branch can be set on a project, when in project directory")
-        .into()),
     }
 }

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,7 +1,4 @@
-use std::collections::BTreeSet;
-use std::io;
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
+use gel_tokio::{Builder, InstanceName, dsn::CredentialsFile};
 
 use anyhow::Context;
 use fn_error_context::context;
@@ -13,89 +10,31 @@ use gel_tokio::{Config, InstanceName};
 use crate::platform::{config_dir, tmp_file_name};
 use crate::question;
 
-pub fn base_dir() -> anyhow::Result<PathBuf> {
-    Ok(config_dir()?.join("credentials"))
+pub fn exists(name: &InstanceName) -> anyhow::Result<bool> {
+    Ok(read(name)?.is_some())
 }
 
-pub fn path(name: &str) -> anyhow::Result<PathBuf> {
-    Ok(base_dir()?.join(format!("{name}.json")))
+pub fn all_instance_names() -> anyhow::Result<Vec<InstanceName>> {
+    Ok(Builder::default().stored_info().credentials().list()?)
 }
 
-pub fn all_instance_names() -> anyhow::Result<BTreeSet<String>> {
-    let mut result = BTreeSet::new();
-    let dir = base_dir()?;
-    let dir_entries = match fs::read_dir(&dir) {
-        Ok(d) => d,
-        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(result),
-        Err(e) => return Err(e).context(format!("error reading {dir:?}")),
-    };
-    for item in dir_entries {
-        let item = item?;
-        if let Ok(filename) = item.file_name().into_string() {
-            if let Some(name) = filename.strip_suffix(".json") {
-                if InstanceName::from_str(name).is_ok() {
-                    result.insert(name.into());
-                }
-            }
-        }
-    }
-    Ok(result)
+pub fn read(name: &InstanceName) -> anyhow::Result<Option<CredentialsFile>> {
+    Ok(Builder::default()
+        .stored_info()
+        .credentials()
+        .read(name.clone())?)
 }
 
-#[tokio::main(flavor = "current_thread")]
-#[context("cannot write credentials file {}", path.display())]
-pub async fn write(path: &Path, credentials: &CredentialsFile) -> anyhow::Result<()> {
-    write_async(path, credentials).await?;
-    Ok(())
+pub fn write(name: &InstanceName, creds: &CredentialsFile) -> anyhow::Result<()> {
+    Ok(Builder::default()
+        .stored_info()
+        .credentials()
+        .write(name.clone(), creds)?)
 }
 
-#[context("cannot write credentials file {}", path.display())]
-pub async fn write_async(path: &Path, credentials: &CredentialsFile) -> anyhow::Result<()> {
-    use tokio::fs;
-
-    fs::create_dir_all(path.parent().unwrap()).await?;
-    let tmp_path = path.with_file_name(tmp_file_name(path));
-    fs::write(&tmp_path, serde_json::to_vec_pretty(&credentials)?).await?;
-    fs::rename(&tmp_path, path).await?;
-    Ok(())
-}
-
-pub async fn read(path: &Path) -> anyhow::Result<CredentialsFile> {
-    use tokio::fs;
-
-    let text = fs::read_to_string(path).await?;
-    Ok(serde_json::from_str(&text)?)
-}
-
-pub fn read_sync(path: &Path) -> anyhow::Result<CredentialsFile> {
-    let text = fs::read_to_string(path)?;
-    Ok(serde_json::from_str(&text)?)
-}
-
-pub fn maybe_update_credentials_file(config: &Config, ask: bool) -> anyhow::Result<()> {
-    if let Some(instance_name) = config.local_instance_name() {
-        if let Ok(creds_path) = path(instance_name) {
-            if let Ok(creds) = config.as_credentials() {
-                let new = serde_json::to_value(&creds)?;
-                let old = serde_json::from_str::<serde_json::Value>(
-                    &std::fs::read_to_string(&creds_path).unwrap_or_default(),
-                )?;
-                if new != old {
-                    log::debug!("old: {old}");
-                    log::debug!("new: {new}");
-                    if !ask
-                        || question::Confirm::new(format!(
-                            "The format of the instance credential file at {} is outdated, \
-                    update now?",
-                            creds_path.display(),
-                        ))
-                        .ask()?
-                    {
-                        std::fs::write(&creds_path, new.to_string())?;
-                    }
-                }
-            }
-        }
-    }
-    Ok(())
+pub fn delete(name: &InstanceName) -> anyhow::Result<()> {
+    Ok(Builder::default()
+        .stored_info()
+        .credentials()
+        .delete(name.clone())?)
 }

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,15 +1,5 @@
 use gel_tokio::{Builder, InstanceName, dsn::CredentialsFile};
 
-use anyhow::Context;
-use fn_error_context::context;
-use fs_err as fs;
-
-use gel_tokio::dsn::CredentialsFile;
-use gel_tokio::{Config, InstanceName};
-
-use crate::platform::{config_dir, tmp_file_name};
-use crate::question;
-
 pub fn exists(name: &InstanceName) -> anyhow::Result<bool> {
     Ok(read(name)?.is_some())
 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -2,9 +2,9 @@ use std::net::SocketAddr;
 
 use colorful::Colorful;
 use gel_cli_instance::docker::{GelDockerInstance, GelDockerInstanceState, GelDockerInstances};
-use gel_dsn::{HostType, gel::TlsSecurity};
 use gel_jwt::{GelPrivateKeyRegistry, Key, KeyRegistry, SigningContext};
 use gel_tokio::Builder;
+use gel_tokio::dsn::{HostType, TlsSecurity};
 use log::warn;
 
 pub enum DockerMode {

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -24,7 +24,6 @@ use crate::classify;
 use crate::cli::logo::print_logo;
 use crate::commands::{ExitCode, backslash};
 use crate::config::Config;
-use crate::credentials;
 use crate::error_display::print_query_error;
 use crate::interrupt::{Interrupt, InterruptError};
 use crate::options::Options;
@@ -113,7 +112,6 @@ pub fn main(options: Options, cfg: Config) -> Result<(), anyhow::Error> {
         .colors(std::io::stdout().is_terminal())
         .clone();
     let conn_config = conn.get()?;
-    credentials::maybe_update_credentials_file(conn_config, true)?;
     let state = repl::State {
         prompt: repl::PromptRpc {
             control: control_wr,

--- a/src/portable/instance/backup.rs
+++ b/src/portable/instance/backup.rs
@@ -103,8 +103,8 @@ fn get_instance(
     instance_name: &InstanceName,
 ) -> anyhow::Result<InstanceHandle> {
     match instance_name {
-        gel_dsn::gel::InstanceName::Local(name) => Ok(get_local_instance(name)?),
-        gel_dsn::gel::InstanceName::Cloud(name) => {
+        InstanceName::Local(name) => Ok(get_local_instance(name)?),
+        InstanceName::Cloud(name) => {
             let client = cloud::client::CloudClient::new(&opts.cloud_options)?;
             client.ensure_authenticated()?;
             Ok(get_cloud_instance(name.clone(), client.api)?)

--- a/src/portable/instance/control.rs
+++ b/src/portable/instance/control.rs
@@ -123,13 +123,12 @@ fn daemon_start(instance: &str) -> anyhow::Result<()> {
 }
 
 pub fn do_start(inst: &InstanceInfo) -> anyhow::Result<()> {
-    let cred_path = credentials::path(&inst.name)?;
-    if !cred_path.exists() {
+    if !credentials::exists(&inst.instance_name)? {
         log::warn!(
-            "No corresponding credentials file {:?} exists. \
+            "No corresponding credentials file exists for {:#}. \
                     Use `{BRANDING_CLI_CMD} instance reset-password -I {}` to create one.",
-            cred_path,
-            inst.name
+            inst.instance_name,
+            inst.instance_name
         );
     }
     if detect_supervisor(&inst.name) {

--- a/src/portable/instance/link.rs
+++ b/src/portable/instance/link.rs
@@ -161,8 +161,8 @@ pub async fn run_async(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
     crate::table::settings(&super::credentials::credentials_table(&config));
     let creds = config.as_credentials()?;
 
-    let (cred_path, instance_name) = match &cmd.name {
-        Some(InstanceName::Local(name)) => (credentials::path(name)?, name.clone()),
+    let instance_name = match &cmd.name {
+        Some(instance @ InstanceName::Local(_)) => instance.clone(),
         Some(InstanceName::Cloud(..)) => unreachable!(),
         None => {
             let default = if opts.conn_options.instance_opts.docker {
@@ -174,7 +174,7 @@ pub async fn run_async(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
                 if !cmd.quiet {
                     eprintln!("Using generated instance name: {}", &default);
                 }
-                (credentials::path(&default)?, default)
+                InstanceName::Local(default)
             } else {
                 loop {
                     let name =
@@ -182,32 +182,32 @@ pub async fn run_async(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
                             .default(&default)
                             .async_ask()
                             .await?;
-                    if matches!(
-                        InstanceName::from_str(&name),
-                        Err(_) | Ok(InstanceName::Cloud { .. })
-                    ) {
-                        print::error!(
-                            "Instance name must be a valid identifier, \
+                    let res = InstanceName::from_str(&name);
+                    match res {
+                        Err(_) | Ok(InstanceName::Cloud { .. }) => {
+                            print::error!(
+                                "Instance name must be a valid identifier, \
                              (regex: ^[a-zA-Z_0-9]+(-[a-zA-Z_0-9]+)*$)"
-                        );
-                        continue;
+                            );
+                            continue;
+                        }
+                        Ok(instance @ InstanceName::Local(_)) => break instance,
                     }
-                    break (credentials::path(&name)?, name);
                 }
             }
         }
     };
-    if cred_path.exists() {
+
+    if credentials::exists(&instance_name)? {
         if cmd.overwrite {
             if !cmd.quiet {
-                print::warn!("Overwriting {}", cred_path.display());
+                print::warn!("Overwriting {instance_name:#}");
             }
         } else if cmd.non_interactive {
-            anyhow::bail!("File {} exists; aborting.", cred_path.display());
+            anyhow::bail!("{instance_name:#} exists; aborting.");
         } else {
             let mut q = question::Confirm::new_dangerous(format!(
-                "{} already exists! Overwrite?",
-                cred_path.display()
+                "{instance_name:#} already exists! Overwrite?"
             ));
             q.default(false);
             if !q.async_ask().await? {
@@ -216,7 +216,7 @@ pub async fn run_async(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
         }
     }
 
-    credentials::write_async(&cred_path, &creds).await?;
+    credentials::write(&instance_name, &creds)?;
     if !cmd.quiet {
         eprintln!(
             "{} To connect run:\
@@ -224,7 +224,7 @@ pub async fn run_async(cmd: &Link, opts: &Options) -> anyhow::Result<()> {
             "Successfully linked to remote instance."
                 .emphasized()
                 .success(),
-            instance_name.escape_default(),
+            instance_name.to_string().escape_default(),
         );
     }
     Ok(())

--- a/src/portable/instance/reset_password.rs
+++ b/src/portable/instance/reset_password.rs
@@ -1,6 +1,5 @@
 use gel_cli_derive::IntoArgs;
-use gel_tokio::InstanceName;
-use gel_tokio::dsn::{CredentialsFile, DEFAULT_USER};
+use gel_tokio::{InstanceName, dsn::DEFAULT_USER};
 use rand::{Rng, SeedableRng};
 
 use edgeql_parser::helpers::{quote_name, quote_string};

--- a/src/portable/instance/status.rs
+++ b/src/portable/instance/status.rs
@@ -14,6 +14,7 @@ use anyhow::Context;
 use fn_error_context::context;
 use gel_cli_derive::IntoArgs;
 use gel_tokio::dsn::{CredentialsFile, DEFAULT_PORT, DEFAULT_USER};
+use gel_tokio::{Builder, CloudName, InstanceName};
 use humantime::format_duration;
 use std::io::IsTerminal;
 use tokio::join;
@@ -21,10 +22,6 @@ use tokio::time::sleep;
 
 use crate::connect::Connection;
 use crate::options::{CloudOptions, InstanceOptionsLegacy};
-use gel_tokio::{
-    Builder, CloudName, InstanceName,
-    dsn::{CredentialsFile, DEFAULT_PORT, DEFAULT_USER},
-};
 
 use crate::branding::{BRANDING_CLOUD, QUERY_TAG};
 use crate::cloud;

--- a/src/portable/instance/upgrade.rs
+++ b/src/portable/instance/upgrade.rs
@@ -8,6 +8,7 @@ use const_format::concatcp;
 use fn_error_context::context;
 use gel_cli_derive::IntoArgs;
 use gel_cli_instance::cloud::CloudInstanceUpgrade;
+use gel_tokio::dsn::DEFAULT_DATABASE_NAME;
 use gel_tokio::{CloudName, InstanceName};
 
 use crate::branding::{BRANDING, BRANDING_CLI_CMD, BRANDING_CLOUD, QUERY_TAG};
@@ -402,12 +403,12 @@ pub fn upgrade_incompatible(
                 paths.dump_path.join("main.dump"),
             )?;
 
-            if let Ok(mut creds) = credentials::read_sync(&paths.credentials) {
-                if creds.database == Some("edgedb".to_string()) {
-                    log::info!("Updating credentials file {:?}", &paths.credentials);
-                    creds.database = Some("main".to_string());
-                    creds.branch = Some("main".to_string());
-                    credentials::write(&paths.credentials, &creds)?;
+            if let Ok(Some(mut creds)) = credentials::read(&inst.instance_name) {
+                if creds.database == Some(DEFAULT_DATABASE_NAME.to_string()) {
+                    log::info!("Updating credentials file");
+                    creds.database = None;
+                    creds.branch = None;
+                    credentials::write(&inst.instance_name, &creds)?;
                 }
             }
         }

--- a/src/portable/local.rs
+++ b/src/portable/local.rs
@@ -15,7 +15,6 @@ use gel_tokio::{Builder, Config, InstanceName};
 
 use crate::branding::BRANDING;
 use crate::bug;
-use crate::credentials;
 use crate::hint::HintExt;
 use crate::platform::{cache_dir, config_dir, data_dir, portable_dir};
 use crate::portable::repository::PackageHash;
@@ -26,7 +25,6 @@ const MIN_PORT: u16 = 10700;
 
 #[derive(Debug)]
 pub struct Paths {
-    pub credentials: PathBuf,
     pub data_dir: PathBuf,
     pub service_files: Vec<PathBuf>,
     pub dump_path: PathBuf,
@@ -273,7 +271,6 @@ impl Paths {
     pub fn get(name: &str) -> anyhow::Result<Paths> {
         let base = data_dir()?;
         Ok(Paths {
-            credentials: credentials::path(name)?,
             data_dir: base.join(name),
             dump_path: base.join(format!("{name}.dump")),
             backup_dir: base.join(format!("{name}.backup")),
@@ -291,9 +288,6 @@ impl Paths {
         })
     }
     pub fn check_exists(&self) -> anyhow::Result<()> {
-        if self.credentials.exists() {
-            anyhow::bail!("Credentials file {:?} already exists", self.credentials);
-        }
         if self.data_dir.exists() {
             anyhow::bail!("Data directory {:?} already exists", self.data_dir);
         }

--- a/src/portable/project/upgrade.rs
+++ b/src/portable/project/upgrade.rs
@@ -134,7 +134,7 @@ pub fn update_toml(
         let database = project::database_name(&stash_dir)?;
         let client = CloudClient::new(&opts.cloud_options)?;
         let mut inst = project::Handle::probe(&name, &project.location.root, &schema_dir, &client)?;
-        inst.database = database;
+        inst.database = database.name().map(|s| s.to_string());
 
         let result = match inst.instance {
             project::InstanceKind::Remote => anyhow::bail!("remote instances cannot be upgraded"),
@@ -231,7 +231,7 @@ pub fn upgrade_instance(cmd: &Command, opts: &crate::options::Options) -> anyhow
     let client = CloudClient::new(&opts.cloud_options)?;
     let mut inst =
         project::Handle::probe(&instance_name, &project.location.root, &schema_dir, &client)?;
-    inst.database = database;
+    inst.database = database.name().map(|s| s.to_string());
     let result = match inst.instance {
         project::InstanceKind::Remote => anyhow::bail!("remote instances cannot be upgraded"),
         project::InstanceKind::Portable(inst) => upgrade_local(cmd, &project, inst, cfg_ver, opts),

--- a/src/process.rs
+++ b/src/process.rs
@@ -11,6 +11,7 @@ use std::sync::LazyLock;
 
 use anyhow::Context;
 use gel_tokio::InstanceName;
+use gel_tokio::dsn::DatabaseBranch;
 use tokio::io::AsyncWriteExt;
 use tokio::io::{self, AsyncBufReadExt, AsyncRead, AsyncReadExt, BufReader};
 use tokio::process::Command;
@@ -149,6 +150,12 @@ impl IntoArg for &usize {
 impl IntoArg for &InstanceName {
     fn add_arg(self, process: &mut Native) {
         process.arg(self.to_string());
+    }
+}
+
+impl IntoArg for &DatabaseBranch {
+    fn add_arg(self, process: &mut Native) {
+        process.arg(self.name().unwrap_or("").to_string());
     }
 }
 


### PR DESCRIPTION
The CLI was failing to load certain outdated credentials files, mostly because we have so many different code paths that load credentials. This moves all of them to the new stored-info handlers in gel-dsn.

Major changes:

 - Credentials are now auto-upgraded in place when necessary. We no longer prompt for upgrades, though in the future we may wish to do opt-in major versioned upgrades.
 - `DatabaseBranch` is used in as many places as we can to avoid ambiguity.