### PR TITLE
Better error message when cloud not loggedi n

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use color_print::cformat;
 use const_format::concatcp;
 use gel_dsn::gel::{TlsSecurity, UnixPath};
-use gel_errors::ClientNoCredentialsError;
+use gel_errors::{ClientNoCredentialsError, NoCloudConfigFound};
 use gel_protocol::model;
 use gel_tokio::{Builder, InstanceName};
 use log::warn;
@@ -1004,6 +1004,18 @@ impl Options {
                 Ok(Connector::new(Ok(config)))
             }
             Err(e) => {
+                if e.is::<NoCloudConfigFound>() {
+                    return Err(anyhow::anyhow!(
+                        "No cloud configuration found, but a cloud instance was specified."
+                    ))
+                    .with_hint(|| {
+                        format!(
+                            "Please run `{BRANDING_CLI_CMD} cloud login` to use cloud instances."
+                        )
+                    })
+                    .map_err(Into::into);
+                }
+
                 let (cfg, errors) = builder.clone().compute()?;
 
                 // ask password anyways, so input that fed as a password
@@ -1036,6 +1048,12 @@ impl Options {
                     };
                     Ok(Connector::new(
                         Err(anyhow::anyhow!(message))
+                            .hint(CONNECTION_ARG_HINT)
+                            .map_err(Into::into),
+                    ))
+                } else if e.is::<NoCloudConfigFound>() {
+                    Ok(Connector::new(
+                        Err(anyhow::anyhow!(""))
                             .hint(CONNECTION_ARG_HINT)
                             .map_err(Into::into),
                     ))


### PR DESCRIPTION
Fixes #1582

```
cargo run -- -I mmastrac/foo
   Compiling gel-cli v7.3.0-dev (/devel/github/edgedb-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.34s
     Running `target/debug/gel -I mmastrac/foo`
                     ▄██▄        
   ▄▄▄▄▄      ▄▄▄    ████        
 ▄███████▄ ▄███████▄ ████        
 ▀███████▀ ▀███▀▀▀▀▀ ████        
   ▀▀▀▀▀      ▀▀▀     ▀▀         
  ▀▄▄▄▄▄▀                 
    ▀▀▀               
gel error: No cloud configuration found, but a cloud instance was specified.
  Hint: Please run `gel cloud login` to use cloud instances.
```