### PR TITLE
Support local instance backups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,12 +1617,14 @@ dependencies = [
  "gel-dsn",
  "humantime-serde",
  "log",
+ "memchr",
  "rstest",
  "scopeguard",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -4745,6 +4747,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/gel-cli-instance/Cargo.toml
+++ b/gel-cli-instance/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-gel-dsn = { workspace = true, features = ["gel"] }
+gel-dsn = { workspace = true, features = ["gel", "unstable"] }
 
 tokio = { version = "1", features = ["process"] }
 futures = "0.3"
@@ -19,8 +19,11 @@ serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 derive_more = { version = "2", features = ["error", "display"] }
 humantime-serde = "1.1.1"
-clap = "4"
+clap = { version = "4", features = ["derive"] }
 anyhow = "1"
+memchr = "2.7"
+uuid = { version = "1", default-features = false, features = ["std", "v7"] }
 
 [dev-dependencies]
 rstest = "0.25"
+tokio = { version = "1", features = ["full"] }

--- a/gel-cli-instance/src/instance/backup.rs
+++ b/gel-cli-instance/src/instance/backup.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::SystemTime};
 
 use gel_dsn::gel::InstanceName;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::Operation;
 
@@ -32,12 +32,23 @@ impl std::ops::Deref for ProgressCallback {
     }
 }
 
-#[derive(Debug, Clone, derive_more::Display, Serialize)]
+#[derive(Debug, Clone, derive_more::Display, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum BackupType {
     #[serde(rename = "automated")]
     Automated,
     #[serde(rename = "manual")]
     Manual,
+    Unknown(String),
+}
+
+#[derive(Debug, Clone, derive_more::Display, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum BackupStrategy {
+    #[serde(rename = "full")]
+    Full,
+    #[serde(rename = "incremental")]
+    Incremental,
+    #[serde(rename = "differential")]
+    Differential,
     Unknown(String),
 }
 
@@ -68,6 +79,7 @@ pub struct Backup {
     pub backup_type: BackupType,
     pub status: String,
     pub server_version: String,
+    pub backup_strategy: BackupStrategy,
 }
 
 pub trait InstanceBackup {

--- a/gel-cli-instance/src/local/localbackup.rs
+++ b/gel-cli-instance/src/local/localbackup.rs
@@ -1,0 +1,247 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+    time::{Duration, SystemTime},
+};
+
+use anyhow::bail;
+use futures::FutureExt;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    ProcessRunner, Processes, SystemProcessRunner,
+    instance::{
+        Operation,
+        backup::{Backup, BackupId, BackupStrategy, BackupType, InstanceBackup, ProgressCallback},
+        map_join_error,
+    },
+};
+
+use super::LocalInstanceHandle;
+
+const BACKUP_TIMEOUT: Duration = Duration::from_secs(60 * 60);
+const BACKUP_LIVENESS_INTERVAL: Duration = Duration::from_secs(60);
+
+pub struct LocalBackup {
+    handle: LocalInstanceHandle,
+}
+
+impl LocalBackup {
+    pub fn new(handle: LocalInstanceHandle) -> Self {
+        Self { handle }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct BackupMetadata {
+    version: u32,
+    #[serde(with = "humantime_serde")]
+    started_at: SystemTime,
+    #[serde(with = "humantime_serde")]
+    last_updated_at: SystemTime,
+    #[serde(with = "humantime_serde")]
+    completed_at: Option<SystemTime>,
+    #[serde(rename = "type")]
+    backup_type: BackupType,
+    #[serde(rename = "strategy")]
+    backup_strategy: BackupStrategy,
+    server_version: String,
+}
+
+impl InstanceBackup for LocalBackup {
+    fn backup(&self, callback: ProgressCallback) -> Operation<Option<BackupId>> {
+        let pg_backup = PgBackupCommands::new(SystemProcessRunner, self.handle.bin_dir.clone());
+        let backup_id = Uuid::now_v7().to_string();
+        let mut backups_dir = self.handle.paths.data_dir.clone();
+        backups_dir.set_extension("backups");
+        let now = SystemTime::now();
+        let mut metadata = BackupMetadata {
+            version: 1,
+            started_at: now,
+            last_updated_at: now,
+            completed_at: None,
+            backup_type: BackupType::Manual,
+            backup_strategy: BackupStrategy::Full,
+            server_version: self.handle.version.clone(),
+        };
+
+        let target_dir = backups_dir.join(&backup_id);
+        let temp_dir = backups_dir.join(format!(".{backup_id}.tmp"));
+        let run_dir = self.handle.run_dir.clone();
+
+        tokio::spawn(async move {
+            let metadata_file = temp_dir.join("backup.json");
+            std::fs::create_dir_all(&temp_dir)?;
+            std::fs::write(&metadata_file, serde_json::to_string_pretty(&metadata)?)?;
+
+            // Update the metadata file every minute so we can detect dead
+            // backup tasks.
+            let task = {
+                let metadata_file = metadata_file.clone();
+                let mut metadata = metadata.clone();
+                tokio::spawn(async move {
+                    loop {
+                        metadata.last_updated_at = SystemTime::now();
+                        let Ok(metadata) = serde_json::to_string_pretty(&metadata) else {
+                            return;
+                        };
+                        _ = std::fs::write(&metadata_file, metadata);
+                        tokio::time::sleep(BACKUP_LIVENESS_INTERVAL).await;
+                    }
+                })
+            };
+
+            let task = scopeguard::guard(task, |task| {
+                let _ = task.abort();
+                // Best effort cleanup
+                _ = std::fs::remove_dir_all(&temp_dir);
+            });
+
+            pg_backup
+                .pg_basebackup(&temp_dir.join("data"), run_dir, "postgres", callback)
+                .await?;
+
+            // Abort the task so we don't accidentally race.
+            let task = scopeguard::ScopeGuard::into_inner(task);
+            task.abort();
+            _ = task.await;
+
+            metadata.completed_at = Some(SystemTime::now());
+            std::fs::write(metadata_file, serde_json::to_string_pretty(&metadata)?)?;
+            std::fs::rename(temp_dir, target_dir)?;
+            Ok(Some(BackupId::new(backup_id)))
+        })
+        .map(map_join_error::<_, anyhow::Error>)
+        .boxed()
+    }
+
+    fn list_backups(&self) -> Operation<Vec<Backup>> {
+        let mut backups_dir = self.handle.paths.data_dir.clone();
+        backups_dir.set_extension("backups");
+
+        tokio::task::spawn_blocking(move || {
+            let mut backups = vec![];
+            let mut to_remove = vec![];
+            if !backups_dir.exists() {
+                return Ok(backups);
+            }
+            for entry in std::fs::read_dir(backups_dir)? {
+                let Ok(entry) = entry else {
+                    continue;
+                };
+                to_remove.push(entry.path());
+                let Ok(uuid) = Uuid::parse_str(&entry.file_name().to_string_lossy()) else {
+                    continue;
+                };
+
+                let path = entry.path();
+                let metadata_file = path.join("backup.json");
+                let Ok(metadata) = std::fs::read_to_string(metadata_file) else {
+                    continue;
+                };
+                let Ok(metadata) = serde_json::from_str::<BackupMetadata>(&metadata) else {
+                    continue;
+                };
+
+                let elapsed = metadata.last_updated_at.elapsed().unwrap_or(Duration::MAX);
+                if elapsed > BACKUP_TIMEOUT {
+                    continue;
+                }
+                to_remove.pop();
+
+                let backup = Backup {
+                    id: BackupId::new(uuid.to_string()),
+                    created_on: metadata.started_at,
+                    status: metadata
+                        .completed_at
+                        .map_or("in progress".to_string(), |_| "completed".to_string()),
+                    backup_type: metadata.backup_type,
+                    backup_strategy: metadata.backup_strategy,
+                    server_version: metadata.server_version,
+                };
+                backups.push(backup);
+            }
+            for path in to_remove {
+                log::warn!("Removing incomplete or failed backup {}", path.display());
+                _ = std::fs::remove_dir_all(&path);
+            }
+            Ok(backups)
+        })
+        .map(map_join_error::<_, anyhow::Error>)
+        .boxed()
+    }
+
+    fn restore(
+        &self,
+        _instance: Option<gel_dsn::gel::InstanceName>,
+        _restore_type: crate::instance::backup::RestoreType,
+        _callback: ProgressCallback,
+    ) -> Operation<()> {
+        async { bail!("`instance restore` is not yet implemented for local instances") }.boxed()
+    }
+}
+
+struct PgBackupCommands<P: ProcessRunner> {
+    runner: Processes<P>,
+    portable_bin_path: PathBuf,
+}
+
+impl<P: ProcessRunner> PgBackupCommands<P> {
+    pub fn new(runner: P, portable_bin_path: PathBuf) -> Self {
+        Self {
+            runner: Processes::new(runner),
+            portable_bin_path,
+        }
+    }
+
+    pub async fn pg_basebackup(
+        &self,
+        target_dir: impl AsRef<Path>,
+        unix_path: impl AsRef<Path>,
+        username: &str,
+        callback: ProgressCallback,
+    ) -> Result<(), anyhow::Error> {
+        if !self.portable_bin_path.join("pg_basebackup").exists() {
+            return Err(anyhow::anyhow!(
+                "Backups not supported for this server version. No `pg_basebackup` found at {}.",
+                self.portable_bin_path.join("pg_basebackup").display()
+            ));
+        }
+        // TODO: we should trigger the server to start if it's not running
+        if !unix_path.as_ref().join(".s.PGSQL.5432").exists() {
+            return Err(anyhow::anyhow!(
+                "PostgreSQL socket not found at {}. Is the instance sleeping?",
+                unix_path.as_ref().join(".s.PGSQL.5432").display()
+            ));
+        }
+        let mut cmd = Command::new(self.portable_bin_path.join("pg_basebackup"));
+        cmd.arg("--pgdata").arg(target_dir.as_ref());
+        cmd.arg("--host").arg(unix_path.as_ref());
+        cmd.arg("--username").arg(username);
+        cmd.arg("--format=tar");
+        cmd.arg("--checkpoint=fast");
+        cmd.arg("--progress");
+        cmd.arg("--compress=client-gzip");
+        // Slows it down
+        // cmd.arg("-r 1000");
+        self.runner
+            .run_lines(cmd, move |line| {
+                callback.progress(None, &format!("running pg_basebackup: {}", line.trim()));
+            })
+            .await?;
+        Ok(())
+    }
+
+    // pub async fn pg_restore(&self, callback: ProgressCallback) -> Result<(), ProcessError> {
+    //     unimplemented!()
+    // }
+
+    // pub async fn pg_combinebackup(&self, callback: ProgressCallback) -> Result<(), ProcessError> {
+    //     unimplemented!()
+    // }
+
+    // pub async fn pg_verifybackup(&self, callback: ProgressCallback) -> Result<(), ProcessError> {
+    //     unimplemented!()
+    // }
+}

--- a/gel-cli-instance/src/local/mod.rs
+++ b/gel-cli-instance/src/local/mod.rs
@@ -1,11 +1,23 @@
-use crate::instance::{Instance, InstanceOpError, backup::InstanceBackup};
+use std::{path::PathBuf, sync::Arc};
 
+use localbackup::LocalBackup;
+
+use crate::instance::{Instance, InstanceOpError, backup::InstanceBackup};
+use gel_dsn::gel::InstancePaths;
+
+mod localbackup;
+
+#[derive(Debug, Clone)]
 pub struct LocalInstanceHandle {
     pub name: String,
+    pub paths: Arc<InstancePaths>,
+    pub bin_dir: PathBuf,
+    pub run_dir: PathBuf,
+    pub version: String,
 }
 
 impl Instance for LocalInstanceHandle {
     fn backup(&self) -> Result<Box<dyn InstanceBackup>, InstanceOpError> {
-        Err(InstanceOpError::Unsupported("local".to_string()))
+        Ok(Box::new(LocalBackup::new(self.clone())))
     }
 }

--- a/src/portable/instance/backup.rs
+++ b/src/portable/instance/backup.rs
@@ -5,9 +5,10 @@ use gel_cli_instance::instance::backup::{ProgressCallbackListener, RestoreType};
 use gel_cli_instance::instance::{InstanceHandle, get_cloud_instance, get_local_instance};
 use gel_tokio::InstanceName;
 
-use crate::branding::{BRANDING_CLI_CMD, BRANDING_CLOUD};
+use crate::branding::BRANDING_CLI_CMD;
 use crate::cloud;
 use crate::options::CloudOptions;
+use crate::portable::local::{InstanceInfo, Paths};
 use crate::print::msg;
 use crate::question;
 
@@ -103,7 +104,24 @@ fn get_instance(
     instance_name: &InstanceName,
 ) -> anyhow::Result<InstanceHandle> {
     match instance_name {
-        gel_dsn::gel::InstanceName::Local(name) => Ok(get_local_instance(name)?),
+        gel_dsn::gel::InstanceName::Local(name) => {
+            let instance_info = InstanceInfo::try_read(name)?;
+            let Some(instance_info) = instance_info else {
+                return Err(anyhow::anyhow!("Remote instances not supported"));
+            };
+            let Some(install_info) = instance_info.installation else {
+                return Err(anyhow::anyhow!("Instance {} not installed", name));
+            };
+            let bin_dir = install_info.base_path()?.join("bin");
+            let run_dir = Paths::get(&name)?.runstate_dir;
+
+            Ok(get_local_instance(
+                name,
+                bin_dir,
+                run_dir,
+                install_info.version.specific().to_string(),
+            )?)
+        }
         gel_dsn::gel::InstanceName::Cloud(name) => {
             let client = cloud::client::CloudClient::new(&opts.cloud_options)?;
             client.ensure_authenticated()?;
@@ -154,7 +172,7 @@ pub async fn backup(cmd: &Backup, opts: &crate::options::Options) -> anyhow::Res
     let backup = get_instance(opts, &cmd.instance)?.backup()?;
 
     let prompt = format!(
-        "Will create a backup for the {BRANDING_CLOUD} instance \"{inst_name}\".\
+        "Will create a backup for {inst_name:#}.\
         \n\nContinue?",
     );
 
@@ -166,9 +184,9 @@ pub async fn backup(cmd: &Backup, opts: &crate::options::Options) -> anyhow::Res
     let backup = backup.backup(progress_bar.into()).await?;
 
     if let Some(backup_id) = backup {
-        msg!("Successfully created a backup {backup_id} for {BRANDING_CLOUD} instance {inst_name}");
+        msg!("Successfully created a backup {backup_id} for {inst_name:#}");
     } else {
-        msg!("Successfully created a backup for {BRANDING_CLOUD} instance {inst_name}");
+        msg!("Successfully created a backup for {inst_name:#}");
     }
     Ok(())
 }
@@ -179,7 +197,7 @@ pub async fn restore(cmd: &Restore, opts: &crate::options::Options) -> anyhow::R
     let backup = get_instance(opts, &cmd.instance)?.backup()?;
 
     let prompt = format!(
-        "Will restore the {BRANDING_CLOUD} instance \"{inst_name}\" from the specified backup.\
+        "Will restore {inst_name:#} from the specified backup.\
         \n\nContinue?",
     );
 
@@ -204,7 +222,7 @@ pub async fn restore(cmd: &Restore, opts: &crate::options::Options) -> anyhow::R
         )
         .await?;
 
-    msg!("{BRANDING_CLOUD} instance {inst_name} has been restored successfully.");
+    msg!("{inst_name:#} has been restored successfully.");
     msg!("To connect to the instance run:");
     msg!("  {BRANDING_CLI_CMD} -I {inst_name}");
     Ok(())


### PR DESCRIPTION
This is a first pass at support local instance backups. 

It requires a running instance (fails if the instance is sleeping), It doesn't support restore or incremental backups, but it will at least perform a local backup.

Further passes will improve the integration with the instance handle (which is a bit too tied with the current backup operation)