### PR TITLE
Skip the update check if the binary was just written

### DIFF
--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -105,10 +105,6 @@ fn _check(cache_dir: &Path, strict: bool) -> anyhow::Result<()> {
     let self_version = cli::upgrade::self_version()?;
     let channel = cli::upgrade::channel();
 
-    if _check_newly_installed().unwrap_or(true) {
-        return Ok(());
-    }
-
     match read_cache(cache_dir) {
         Ok(cache) if cache.expires > SystemTime::now() && cache.channel_matches(&channel) => {
             log::debug!("Cached version {:?}", cache.version);
@@ -161,6 +157,10 @@ fn cache_dir() -> anyhow::Result<PathBuf> {
 }
 
 pub fn check(no_version_check_opt: bool) -> anyhow::Result<()> {
+    if _check_newly_installed().unwrap_or(true) {
+        return Ok(());
+    }
+
     use cli::env::VersionCheck;
     let mut strict = false;
     if no_version_check_opt {


### PR DESCRIPTION
This potentially helps with getting flagged by Windows anti-virus. Instead of doing an update check after we freshly install the CLI, we check the CLI modification/creation dates and wait until the CLI binary is sufficiently old enough (1 day) before checking.

We don't skip the check if either date is in the future. 

The untested theory is that we are doing too much on first start. The heuristic/AI-based malware detectors use behaviour-on-first-boot as a way to categorize things as sketchy or not, but do not take into account the reputation of the domains we are communicating with.

This removes a network check on most first boots, which hopefully makes it look less suspicious.
