### PR TITLE
Local instance restore 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1622,6 +1622,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
+ "tar",
  "thiserror 2.0.12",
  "tokio",
  "uuid",
@@ -1641,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "gel-dsn"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23add067c55429ae5371b3cab23b9f275722841b8d04a283df5ba639a7b99834"
+checksum = "591c592aa7be65a0391c2a9b3d9388db494778f1a26c0078cb38c7bd9faf6677"
 dependencies = [
  "base64 0.22.1",
  "crc16",
@@ -1749,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "gel-tokio"
-version = "0.10.10"
+version = "0.10.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aaac12541a8b478cafc83ed2ecf512c072b0b788e77ab8ba66209c40bc7dcec"
+checksum = "b0e985ac7a4450ec2d256411c5c672ae1391d06bd075253dad1b63b6b95ad19b"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1643,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "gel-dsn"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591c592aa7be65a0391c2a9b3d9388db494778f1a26c0078cb38c7bd9faf6677"
+checksum = "cb0c27dda7e5d5e1364552ba8912b2c247c3c63c08189987c17e7fda927280c2"
 dependencies = [
  "base64 0.22.1",
  "crc16",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,6 +1613,7 @@ dependencies = [
  "bytes",
  "clap",
  "derive_more",
+ "flate2",
  "futures",
  "gel-dsn",
  "humantime-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ backtrace = "0.3.61"
 arc-swap = "1.4.0"
 ctrlc = "3.2.0"
 crossbeam-utils = "0.8.5"
-tar = "0.4.37"
+tar = "0.4.44"
 zstd = "0.13"
 semver = {version="1.0.4", features=["serde"]}
 fd-lock = "4.0.2"

--- a/gel-cli-instance/Cargo.toml
+++ b/gel-cli-instance/Cargo.toml
@@ -23,6 +23,7 @@ clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 memchr = "2.7"
 uuid = { version = "1", default-features = false, features = ["std", "v7"] }
+tar = "0.4.44"
 
 [dev-dependencies]
 rstest = "0.25"

--- a/gel-cli-instance/Cargo.toml
+++ b/gel-cli-instance/Cargo.toml
@@ -23,7 +23,8 @@ clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 memchr = "2.7"
 uuid = { version = "1", default-features = false, features = ["std", "v7"] }
-tar = "0.4.44"
+tar = { version = "0.4.44", default-features = false }
+flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
 
 [dev-dependencies]
 rstest = "0.25"

--- a/gel-cli-instance/src/instance/mod.rs
+++ b/gel-cli-instance/src/instance/mod.rs
@@ -57,7 +57,6 @@ pub fn get_cloud_instance<H: CloudHttp>(
 pub fn get_local_instance(
     name: &str,
     bin_dir: PathBuf,
-    run_dir: PathBuf,
     version: String,
 ) -> Result<InstanceHandle, InstanceOpError> {
     let paths = Builder::default().with_system().stored_info().paths();
@@ -68,7 +67,6 @@ pub fn get_local_instance(
         name: name.to_string(),
         paths: Arc::new(instance_paths),
         bin_dir,
-        run_dir,
         version,
     };
     Ok(InstanceHandle {

--- a/gel-cli-instance/src/local/mod.rs
+++ b/gel-cli-instance/src/local/mod.rs
@@ -12,7 +12,6 @@ pub struct LocalInstanceHandle {
     pub name: String,
     pub paths: Arc<InstancePaths>,
     pub bin_dir: PathBuf,
-    pub run_dir: PathBuf,
     pub version: String,
 }
 

--- a/src/portable/instance/backup.rs
+++ b/src/portable/instance/backup.rs
@@ -8,7 +8,7 @@ use gel_tokio::InstanceName;
 use crate::branding::BRANDING_CLI_CMD;
 use crate::cloud;
 use crate::options::CloudOptions;
-use crate::portable::local::{InstanceInfo, Paths};
+use crate::portable::local::InstanceInfo;
 use crate::print::msg;
 use crate::question;
 
@@ -113,12 +113,10 @@ fn get_instance(
                 return Err(anyhow::anyhow!("Instance {} not installed", name));
             };
             let bin_dir = install_info.base_path()?.join("bin");
-            let run_dir = Paths::get(&name)?.runstate_dir;
 
             Ok(get_local_instance(
                 name,
                 bin_dir,
-                run_dir,
                 install_info.version.specific().to_string(),
             )?)
         }


### PR DESCRIPTION
Adds `instance restore` to local instances. For the initial implementation of this feature, the server must be stopped.

We run `pg_verifybackup` and unpack the backup data and WAL files to a new server folder.

Note that we need to ship `pg_waldump` with the server binaries for this to work.