### PR TITLE
Bump ubuntu 20 -> 22

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-latest, macos-latest, windows-2019]
+        os: [ubuntu-22.04, ubuntu-latest, macos-latest, windows-2019]
         # migrations tests work only on nightly
         edgedb-version: ["nightly"]
     steps:
@@ -95,7 +95,7 @@ jobs:
     timeout-minutes: 35
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Ubuntu 20 runners are kaput, we need to move to at least 22.

https://github.com/actions/runner-images/issues/11101