### PR TITLE
Handle empty output from slurp-like commands

### DIFF
--- a/gel-cli-instance/src/lib.rs
+++ b/gel-cli-instance/src/lib.rs
@@ -171,7 +171,9 @@ impl<P: ProcessRunner> Processes<P> {
     ) -> Result<Vec<T>, ProcessError> {
         Self::with_cmd(command, |cmd| async move {
             let bytes = self.run_bytes(cmd).await?;
-            if bytes[0] == b'[' {
+            if bytes.is_empty() {
+                Ok(Vec::new())
+            } else if bytes[0] == b'[' {
                 Ok(serde_json::from_slice(&bytes)?)
             } else {
                 Ok(serde_json::StreamDeserializer::new(SliceRead::new(&bytes))


### PR DESCRIPTION
Fixes https://github.com/geldata/gel-cli/issues/1603 by handling empty output from docker.