### PR TITLE
Fix squashing of long migration histories

### DIFF
--- a/src/migrations/squash.rs
+++ b/src/migrations/squash.rs
@@ -265,8 +265,6 @@ impl TwoStageRemove<'_> {
             }
             if lossy_name.ends_with(".edgeql") {
                 self.rename(&item.path()).await?;
-            } else if lossy_name.ends_with(".edgeql.old") {
-                self.filenames.push(item.path());
             }
         }
         Ok(())

--- a/src/migrations/squash.rs
+++ b/src/migrations/squash.rs
@@ -292,3 +292,46 @@ impl TwoStageRemove<'_> {
         Ok(())
     }
 }
+
+#[tokio::test]
+async fn test_two_stage_remove() -> anyhow::Result<()> {
+    // Test for #1610, which fixed a bug when there were too many
+    // migration files for one call to getdents64.
+
+    // Put the temp dir under (unfortunately) the current directory.
+    // This is because /tmp is often a tmpfs, and the issue doesn't
+    // show up on tmpfs!
+    let tmp = tempfile::tempdir_in(".")?;
+
+    let ctx = Context {
+        schema_dir: tmp.path().to_path_buf(),
+        quiet: false,
+        project: None,
+    };
+
+    // Create test migration files
+    let migrations_dir = tmp.path().join("migrations");
+    fs::create_dir(&migrations_dir).await?;
+    for i in 0..2000 {
+        fs::write(migrations_dir.join(format!("{:05}-mXXXXXX.edgeql", i)), "").await?;
+    }
+
+    // Run rename + removal
+    let mut remover = TwoStageRemove::new(&ctx);
+    remover.rename_revisions().await?;
+    remover.commit().await?;
+
+    // Verify files are removed
+    let mut entries = fs::read_dir(&migrations_dir).await?;
+    while let Some(item) = entries.next_entry().await? {
+        let file_name = item.file_name();
+        let name = file_name.to_string_lossy();
+        assert!(
+            !name.ends_with(".edgeql") && !name.ends_with(".edgeql.old"),
+            "Found unexpected file: {}",
+            name
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
When deleting old migration scripts during squash, we first rename
them to `.old.edgeql` and then delete them.  While looping through the
directory contents, if we see an existing `.old.edgeql`, we register
that to be deleted too.

However, we are iterating through the directory as we do this, so it
is possible that we will see a file that was just *renamed* and thus
is already registered to be deleted, and which we will then try to
delete twice.

On linux, this happens if there too many files to fit in one call to
`getdents64` with whatever buffer size libc is using.  To make things
extra fun, I originally struggled to reproduce this because glibc uses
a much larger buffer size than musl does (32k vs 2k).

Fix by just dropping the deletion of existing `.edgeql.old` files. I
don't think they should be there for any reason of ours, and so we
don't want to mess with them?
I don't feel strongly, though; we could also skip duplicates.

Tested manually; I didn't include a test because the long migration
history is a pain.

Fixes #1609.