### PR TITLE
Apply hooks in dev_mode

### DIFF
--- a/src/migrations/apply.rs
+++ b/src/migrations/apply.rs
@@ -484,9 +484,21 @@ pub async fn apply_migrations(
     ctx: &Context,
     single_transaction: bool,
 ) -> anyhow::Result<()> {
-    if let Some(project) = &ctx.project {
-        hooks::on_action("migration.apply.before", project).await?;
-        hooks::on_action("schema.update.before", project).await?;
+    apply_migrations_ext(cli, migrations, ctx, single_transaction, true).await
+}
+
+pub async fn apply_migrations_ext(
+    cli: &mut Connection,
+    migrations: &(impl AsOperations + ?Sized),
+    ctx: &Context,
+    single_transaction: bool,
+    apply_hooks: bool,
+) -> anyhow::Result<()> {
+    if apply_hooks {
+        if let Some(project) = &ctx.project {
+            hooks::on_action("migration.apply.before", project).await?;
+            hooks::on_action("schema.update.before", project).await?;
+        }
     }
 
     let old_timeout = timeout::inhibit_for_transaction(cli).await?;
@@ -515,9 +527,11 @@ pub async fn apply_migrations(
             }
         }
     }?;
-    if let Some(project) = &ctx.project {
-        hooks::on_action("migration.apply.after", project).await?;
-        hooks::on_action("schema.update.after", project).await?;
+    if apply_hooks {
+        if let Some(project) = &ctx.project {
+            hooks::on_action("migration.apply.after", project).await?;
+            hooks::on_action("schema.update.after", project).await?;
+        }
     }
     Ok(())
 }

--- a/src/migrations/apply.rs
+++ b/src/migrations/apply.rs
@@ -484,21 +484,9 @@ pub async fn apply_migrations(
     ctx: &Context,
     single_transaction: bool,
 ) -> anyhow::Result<()> {
-    apply_migrations_ext(cli, migrations, ctx, single_transaction, true).await
-}
-
-pub async fn apply_migrations_ext(
-    cli: &mut Connection,
-    migrations: &(impl AsOperations + ?Sized),
-    ctx: &Context,
-    single_transaction: bool,
-    apply_hooks: bool,
-) -> anyhow::Result<()> {
-    if apply_hooks {
-        if let Some(project) = &ctx.project {
-            hooks::on_action("migration.apply.before", project).await?;
-            hooks::on_action("schema.update.before", project).await?;
-        }
+    if let Some(project) = &ctx.project {
+        hooks::on_action("migration.apply.before", project).await?;
+        hooks::on_action("schema.update.before", project).await?;
     }
 
     let old_timeout = timeout::inhibit_for_transaction(cli).await?;
@@ -527,11 +515,9 @@ pub async fn apply_migrations_ext(
             }
         }
     }?;
-    if apply_hooks {
-        if let Some(project) = &ctx.project {
-            hooks::on_action("migration.apply.after", project).await?;
-            hooks::on_action("schema.update.after", project).await?;
-        }
+    if let Some(project) = &ctx.project {
+        hooks::on_action("migration.apply.after", project).await?;
+        hooks::on_action("schema.update.after", project).await?;
     }
     Ok(())
 }

--- a/src/migrations/dev_mode.rs
+++ b/src/migrations/dev_mode.rs
@@ -165,7 +165,7 @@ async fn migrate_to_schema(cli: &mut Connection, ctx: &Context) -> anyhow::Resul
     use gel_protocol::server_message::TransactionState::NotInTransaction;
 
     let old_timeout = timeout::inhibit_for_transaction(cli).await?;
-    async_try!{
+    async_try! {
         async {
             if matches!(cli.transaction_state(), NotInTransaction) {
                 execute(cli, "START TRANSACTION", None).await?;

--- a/src/migrations/dev_mode.rs
+++ b/src/migrations/dev_mode.rs
@@ -10,8 +10,7 @@ use crate::async_try;
 use crate::branding::BRANDING;
 use crate::bug;
 use crate::commands::Options;
-use crate::hooks;
-use crate::migrations::apply::{apply_migrations_ext, apply_migrations_inner};
+use crate::migrations::apply::{apply_migrations, apply_migrations_inner};
 use crate::migrations::context::Context;
 use crate::migrations::create;
 use crate::migrations::create::{CurrentMigration, FutureMigration};
@@ -32,12 +31,6 @@ pub async fn migrate(cli: &mut Connection, ctx: &Context, bar: &ProgressBar) -> 
     }
     let migrations = migration::read_all(ctx, true).await?;
     let db_migration = get_db_migration(cli).await?;
-
-    if let Some(project) = &ctx.project {
-        hooks::on_action("migration.apply.before", project).await?;
-        hooks::on_action("schema.update.before", project).await?;
-    }
-
     match select_mode(cli, &migrations, db_migration.as_deref()).await? {
         Mode::Normal { skip } => {
             log::info!("Skipping {} revisions.", skip);
@@ -46,7 +39,7 @@ pub async fn migrate(cli: &mut Connection, ctx: &Context, bar: &ProgressBar) -> 
                 .ok_or_else(|| bug::error("`skip` is out of range"))?;
             if !migrations.is_empty() {
                 bar.set_message("Applying migrations");
-                apply_migrations_ext(cli, migrations, ctx, false, false).await?;
+                apply_migrations(cli, migrations, ctx, false).await?;
                 bar.println("Migrations applied");
             }
 
@@ -74,12 +67,6 @@ pub async fn migrate(cli: &mut Connection, ctx: &Context, bar: &ProgressBar) -> 
             }
         }
     }
-
-    if let Some(project) = &ctx.project {
-        hooks::on_action("migration.apply.after", project).await?;
-        hooks::on_action("schema.update.after", project).await?;
-    }
-
     Ok(())
 }
 


### PR DESCRIPTION
`gel watch --migrate` and `gel migrate --dev-mode` should trigger `migration.apply.*` and `schema.update.*` hooks if the schema is changed.

Refs #1449 