### PR TITLE
Implement incremental backup

### DIFF
--- a/gel-cli-instance/src/cloud/instance.rs
+++ b/gel-cli-instance/src/cloud/instance.rs
@@ -3,9 +3,12 @@ use gel_dsn::gel::{CloudName, InstanceName};
 use std::time::Duration;
 
 use crate::instance::{
+    Instance, InstanceOpError, Operation,
     backup::{
-        Backup, BackupId, BackupStrategy, BackupType, InstanceBackup, ProgressCallback, RequestedBackupStrategy, RestoreType
-    }, map_join_error, Instance, InstanceOpError, Operation
+        Backup, BackupId, BackupStrategy, BackupType, InstanceBackup, ProgressCallback,
+        RequestedBackupStrategy, RestoreType,
+    },
+    map_join_error,
 };
 
 use super::{CloudApi, CloudError, CloudHttp, schema};
@@ -21,7 +24,11 @@ struct CloudInstanceBackup<H: CloudHttp> {
 }
 
 impl<H: CloudHttp> InstanceBackup for CloudInstanceBackup<H> {
-    fn backup(&self, strategy: RequestedBackupStrategy, callback: ProgressCallback) -> Operation<Option<BackupId>> {
+    fn backup(
+        &self,
+        strategy: RequestedBackupStrategy,
+        callback: ProgressCallback,
+    ) -> Operation<Option<BackupId>> {
         let api = self.instance.api.clone();
         let name = self.instance.name.clone();
 

--- a/gel-cli-instance/src/instance/backup.rs
+++ b/gel-cli-instance/src/instance/backup.rs
@@ -82,9 +82,17 @@ pub struct Backup {
     pub backup_strategy: BackupStrategy,
 }
 
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+pub enum RequestedBackupStrategy {
+    #[default]
+    Auto,
+    Full,
+    Incremental,
+}
+
 pub trait InstanceBackup {
     /// Perform a backup. Returns the backup id if available.
-    fn backup(&self, callback: ProgressCallback) -> Operation<Option<BackupId>>;
+    fn backup(&self, strategy: RequestedBackupStrategy, callback: ProgressCallback) -> Operation<Option<BackupId>>;
     /// Restore from a backup, optionally from a different instance.
     fn restore(
         &self,

--- a/gel-cli-instance/src/instance/backup.rs
+++ b/gel-cli-instance/src/instance/backup.rs
@@ -58,7 +58,7 @@ pub enum RestoreType {
     Specific(String),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::Display, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::Display, Serialize, Deserialize)]
 #[display("{}", id)]
 #[serde(transparent)]
 pub struct BackupId {
@@ -92,7 +92,11 @@ pub enum RequestedBackupStrategy {
 
 pub trait InstanceBackup {
     /// Perform a backup. Returns the backup id if available.
-    fn backup(&self, strategy: RequestedBackupStrategy, callback: ProgressCallback) -> Operation<Option<BackupId>>;
+    fn backup(
+        &self,
+        strategy: RequestedBackupStrategy,
+        callback: ProgressCallback,
+    ) -> Operation<Option<BackupId>>;
     /// Restore from a backup, optionally from a different instance.
     fn restore(
         &self,

--- a/gel-cli-instance/src/local/localbackup.rs
+++ b/gel-cli-instance/src/local/localbackup.rs
@@ -13,15 +13,11 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
-    ProcessRunner, Processes, SystemProcessRunner,
     instance::{
-        Operation,
         backup::{
-            Backup, BackupId, BackupStrategy, BackupType, InstanceBackup, ProgressCallback,
-            RestoreType,
-        },
-        map_join_error,
-    },
+            Backup, BackupId, BackupStrategy, BackupType, InstanceBackup, ProgressCallback, RequestedBackupStrategy, RestoreType
+        }, map_join_error, Operation
+    }, ProcessRunner, Processes, SystemProcessRunner
 };
 
 use super::LocalInstanceHandle;
@@ -79,7 +75,7 @@ impl BackupMetadata {
 }
 
 impl InstanceBackup for LocalBackup {
-    fn backup(&self, callback: ProgressCallback) -> Operation<Option<BackupId>> {
+    fn backup(&self, strategy: RequestedBackupStrategy, callback: ProgressCallback) -> Operation<Option<BackupId>> {
         let pg_backup = PgBackupCommands::new(SystemProcessRunner, self.handle.bin_dir.clone());
         let backup_id = Uuid::now_v7().to_string();
         let mut backups_dir = self.handle.paths.data_dir.clone();

--- a/src/portable/instance/backup.rs
+++ b/src/portable/instance/backup.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use futures_util::future;
 use gel_cli_derive::IntoArgs;
 use gel_cli_instance::instance::backup::{
-    ProgressCallbackListener, RequestedBackupStrategy, RestoreType,
+    BackupStrategy, ProgressCallbackListener, RequestedBackupStrategy, RestoreType,
 };
 use gel_cli_instance::instance::{InstanceHandle, get_cloud_instance, get_local_instance};
 use gel_tokio::InstanceName;
@@ -150,10 +150,14 @@ pub async fn list(cmd: &ListBackups, opts: &crate::options::Options) -> anyhow::
                 .collect(),
         ));
         for key in backups {
+            let backup_type = match key.backup_strategy {
+                BackupStrategy::Full => format!("{}", key.backup_type),
+                other => format!("{} ({:?})", key.backup_type, other),
+            };
             table.add_row(Row::new(vec![
                 Cell::new(&key.id.to_string()),
                 Cell::new(&humantime::format_rfc3339_seconds(key.created_on).to_string()),
-                Cell::new(&key.backup_type.to_string()),
+                Cell::new(&backup_type),
                 Cell::new(&key.status),
                 Cell::new(&key.server_version),
             ]));


### PR DESCRIPTION
Performing a backup for an instance will now use an "automatic" mode where we perform an incremental backup if the current backup's "generation" is <= 5 (an arbitrary number to avoid incrementals becoming too deeply nested) or if the previous backup is older than a week.

We also terminate and start the instance appropriately for backup and restore to take place.