### PR TITLE
Initial locking implementation

### DIFF
--- a/.github/workflows/new-tests.yml
+++ b/.github/workflows/new-tests.yml
@@ -142,7 +142,7 @@ jobs:
           gel instance create -I _placeholder_
           gel instance destroy --non-interactive -I _placeholder_
           wsl cp artifacts/debug-gel-cli-Linux/gel /usr/bin/gel.new
-          wsl --exec cp /usr/bin/gel.new /usr/bin/gel && cp /usr/bin/gel.new /usr/bin/edgedb
+          wsl --exec 'cp /usr/bin/gel.new /usr/bin/gel && cp /usr/bin/gel.new /usr/bin/edgedb'
 
       - name: Set executable permissions
         if: runner.os != 'Windows'

--- a/.github/workflows/new-tests.yml
+++ b/.github/workflows/new-tests.yml
@@ -141,8 +141,8 @@ jobs:
         run: |
           gel instance create -I _placeholder_
           gel instance destroy --non-interactive -I _placeholder_
-          wsl cp artifacts/debug-gel-cli-Linux/gel /usr/bin/edgedb
-          wsl cp artifacts/debug-gel-cli-Linux/gel /usr/bin/gel
+          wsl cp artifacts/debug-gel-cli-Linux/gel /usr/bin/gel.new
+          wsl --exec cp /usr/bin/gel.new /usr/bin/gel && cp /usr/bin/gel.new /usr/bin/edgedb
 
       - name: Set executable permissions
         if: runner.os != 'Windows'

--- a/.github/workflows/new-tests.yml
+++ b/.github/workflows/new-tests.yml
@@ -142,7 +142,7 @@ jobs:
           gel instance create -I _placeholder_
           gel instance destroy --non-interactive -I _placeholder_
           wsl cp artifacts/debug-gel-cli-Linux/gel /usr/bin/gel.new
-          wsl --exec 'cp /usr/bin/gel.new /usr/bin/gel && cp /usr/bin/gel.new /usr/bin/edgedb'
+          wsl --exec sh -c 'cp /usr/bin/gel.new /usr/bin/gel && cp /usr/bin/gel.new /usr/bin/edgedb'
 
       - name: Set executable permissions
         if: runner.os != 'Windows'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,6 +1256,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-guard"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ef72acf95ec3d7dbf61275be556299490a245f017cf084bd23b4f68cf9407c"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,6 +1513,7 @@ dependencies = [
  "edgeql-parser",
  "env_logger",
  "fd-lock",
+ "file-guard",
  "fn-error-context",
  "fs-err",
  "fs_extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,7 @@ terminal-light = {git = "https://github.com/msullivan/terminal-light"}
 globset = "0.4.15"
 x509-parser = "0.17.0"
 async-fn-stream = "0.2.2"
+file-guard = "0.2.0"
 
 [dependencies.bzip2]
 version = "*"

--- a/src/branch/context.rs
+++ b/src/branch/context.rs
@@ -4,7 +4,7 @@ use log::warn;
 
 use crate::connect::Connection;
 use crate::credentials;
-use crate::locking::{InstanceLock, LockManager, ProjectLock};
+use crate::locking::{InstanceLock, LockManager};
 use crate::platform::tmp_file_path;
 use crate::portable::project::{self, get_stash_path};
 use std::fs;

--- a/src/branch/mod.rs
+++ b/src/branch/mod.rs
@@ -20,7 +20,13 @@ pub async fn run(
     options: &Options,
     conn: Option<&mut Connection>,
 ) -> anyhow::Result<CommandResult> {
-    let context = context::Context::new(options.instance_name.as_ref(), options.skip_hooks).await?;
+    let read_only = matches!(&cmd, Subcommand::List(..) | Subcommand::Current(..));
+    let context = context::Context::new(
+        options.instance_name.as_ref(),
+        options.skip_hooks,
+        read_only,
+    )
+    .await?;
 
     let mut connector: Connector = options.conn_params.clone();
 

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -131,6 +131,10 @@ define_env! {
     /// Skip any project hooks defined in gel.toml
     #[env(GEL_SKIP_HOOKS)]
     skip_hooks: BoolFlag,
+
+    /// Whether we are running in a hook
+    #[env(_GEL_IN_HOOK)]
+    in_hook: BoolFlag,
 }
 
 pub fn get_envs(names: &[&str]) -> Result<Option<(String, String)>, anyhow::Error> {
@@ -192,6 +196,7 @@ impl std::str::FromStr for InstallInDocker {
     }
 }
 
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub struct BoolFlag(pub bool);
 
 impl std::str::FromStr for BoolFlag {
@@ -203,5 +208,13 @@ impl std::str::FromStr for BoolFlag {
             "false" | "0" => Ok(Self(false)),
             _ => Err(format!("Invalid boolean value: {}", s)),
         }
+    }
+}
+
+impl std::ops::Deref for BoolFlag {
+    type Target = bool;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -88,6 +88,7 @@ pub async fn wipe(
     let context = crate::branch::context::Context::new(
         cmd.instance_opts.maybe_instance().as_ref(),
         skip_hooks,
+        false,
     )
     .await?;
     crate::branch::wipe::do_wipe(connection, &context).await?;

--- a/src/commands/dump.rs
+++ b/src/commands/dump.rs
@@ -16,6 +16,7 @@ use crate::commands::list_databases::get_databases;
 use crate::commands::parser::{Dump as DumpOptions, DumpFormat};
 use crate::connect::Connection;
 use crate::hint::HintExt;
+use crate::locking::LockManager;
 use crate::platform::tmp_file_name;
 use crate::portable::ver;
 
@@ -86,6 +87,12 @@ pub async fn dump(
     general: &Options,
     options: &DumpOptions,
 ) -> Result<(), anyhow::Error> {
+    let _lock = if let Some(instance) = &general.instance_name {
+        Some(LockManager::lock_read_instance_async(&instance).await?)
+    } else {
+        None
+    };
+
     if options.all {
         if let Some(dformat) = options.format {
             if dformat != DumpFormat::Dir {

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -26,6 +26,7 @@ use crate::commands::Options;
 use crate::commands::list_databases;
 use crate::commands::parser::Restore as RestoreCmd;
 use crate::connect::Connection;
+use crate::locking::LockManager;
 use crate::statement::{EndOfFile, read_statement};
 
 type Input = Box<dyn AsyncRead + Unpin + Send>;
@@ -226,6 +227,11 @@ pub async fn restore(
     options: &Options,
     params: &RestoreCmd,
 ) -> Result<(), anyhow::Error> {
+    let _lock = if let Some(instance) = &options.instance_name {
+        Some(LockManager::lock_instance_async(&instance).await?)
+    } else {
+        None
+    };
     if params.all {
         Box::pin(restore_all(cli, options, params)).await
     } else {

--- a/src/locking.rs
+++ b/src/locking.rs
@@ -103,10 +103,10 @@ fn try_create_lock_inner(
         .create(true)
         .read(true)
         .write(true)
-        .append(true)
         .open(path)?;
     let lock_file = Box::new(lock_file);
     let mut lock = file_guard::try_lock(lock_file, lock_type, 0, 1)?;
+
     // Once we get the lock, rewrite the file with our data
     lock.set_len(0)?;
     lock.write_all(

--- a/src/locking.rs
+++ b/src/locking.rs
@@ -3,30 +3,35 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
     sync::{Arc, atomic::AtomicBool},
+    time::{Duration, Instant},
 };
 
-use gel_tokio::{InstanceName, dsn::StoredInformation};
-use log::warn;
+use gel_tokio::InstanceName;
+use log::{debug, warn};
 use serde_json::json;
 
-struct Lock {}
+use crate::portable::project::get_stash_path;
+
+const LOCK_FILE_NAME: &str = "gel-cli.lock";
+const SLOW_LOCK_WARNING: Duration = Duration::from_secs(10);
+const SLOW_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone)]
 pub struct InstanceLock {
-    inner: Arc<InstanceLockInner>,
+    inner: Arc<LockInner>,
 }
 
 impl InstanceLock {
     /// Notify the lock that it will be removed externally.
     pub fn lock_will_be_removed(&self) {
-        if let InstanceLockInner::Local(_, _, must_exist) = &*self.inner {
+        if let LockInner::Local(_, _, must_exist) = &*self.inner {
             must_exist.store(false, std::sync::atomic::Ordering::Relaxed);
         }
     }
 }
 
 #[derive(Debug)]
-enum InstanceLockInner {
+enum LockInner {
     NoLock,
     Local(
         PathBuf,
@@ -35,9 +40,9 @@ enum InstanceLockInner {
     ),
 }
 
-impl Drop for InstanceLockInner {
+impl Drop for LockInner {
     fn drop(&mut self) {
-        if let InstanceLockInner::Local(path, lock, must_exist) = self {
+        if let LockInner::Local(path, lock, must_exist) = self {
             if let Some(lock) = lock.take() {
                 drop(lock);
                 if let Err(e) = std::fs::remove_file(&path) {
@@ -51,40 +56,138 @@ impl Drop for InstanceLockInner {
 }
 
 #[derive(Debug, Clone)]
-pub struct ProjectLock {}
+pub struct ProjectLock {
+    inner: Arc<LockInner>,
+}
 
 pub struct LockManager {}
 
 #[derive(thiserror::Error, Debug)]
-pub enum LockError {}
-
-struct LockManagerInstance {}
-
-impl LockManagerInstance {
-    pub fn new() {}
+pub enum LockError {
+    #[error("Could not acquire lock being held by process {pid} running {cmd:?}")]
+    Locked { pid: u32, cmd: String },
+    #[error("Lock file {path:?} is missing or corrupt")]
+    BadLockFile { path: PathBuf },
+    #[error("I/O error: {error}")]
+    IOError {
+        path: PathBuf,
+        error: std::io::Error,
+    },
 }
 
-fn try_create_lock(path: PathBuf) -> Result<InstanceLockInner, LockError> {
+fn try_create_lock(lock_type: file_guard::Lock, path: PathBuf) -> Result<LockInner, LockError> {
     let mut lock_file = OpenOptions::new()
         .create(true)
         .truncate(true)
         .write(true)
         .open(&path)
         .unwrap();
-    lock_file
-        .write_all(
-            json!({"pid": std::process::id(), "cmd": std::env::args().collect::<Vec<_>>()})
-                .to_string()
-                .as_bytes(),
-        )
-        .unwrap();
+    lock_file.write_all(
+        json!({"pid": std::process::id(), "cmd": std::env::args().collect::<Vec<_>>().join(" ")})
+            .to_string()
+            .as_bytes(),
+    ).map_err(|e| LockError::IOError { path: path.clone(), error: e })?;
     let lock_file = Arc::new(lock_file);
-    let lock = file_guard::lock(lock_file, file_guard::Lock::Exclusive, 0, 1).unwrap();
-    Ok(InstanceLockInner::Local(
-        path,
-        Some(lock),
-        AtomicBool::new(true),
-    ))
+    let lock =
+        file_guard::try_lock(lock_file, lock_type, 0, 1).map_err(|e| LockError::IOError {
+            path: path.clone(),
+            error: e,
+        })?;
+    debug!("Lock created: {path:?}");
+    Ok(LockInner::Local(path, Some(lock), AtomicBool::new(true)))
+}
+
+fn try_create_lock_loop_sync(
+    lock_type: file_guard::Lock,
+    path: PathBuf,
+) -> Result<LockInner, LockError> {
+    let start = Instant::now();
+    let mut warned = false;
+    let mut first = true;
+    loop {
+        match try_create_lock(lock_type, path.clone()) {
+            Ok(lock) => return Ok(lock),
+            Err(e) => {
+                if first {
+                    if let Ok(cmd) = std::fs::read_to_string(&path) {
+                        let Ok(cmd) = serde_json::from_str::<serde_json::Value>(&cmd) else {
+                            return Err(LockError::BadLockFile { path });
+                        };
+                        warn!(
+                            "Waiting for lock held by process {pid} running {cmd:?}",
+                            pid = cmd["pid"].as_u64().unwrap() as u32,
+                            cmd = cmd["cmd"].as_str().unwrap().to_string()
+                        );
+                    }
+                    first = false;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                if start.elapsed() > SLOW_LOCK_WARNING {
+                    if !warned {
+                        warn!("Still waiting for lock ({path:?})");
+                        warned = true;
+                    }
+                }
+                if start.elapsed() > SLOW_LOCK_TIMEOUT {
+                    if let Ok(cmd) = std::fs::read_to_string(&path) {
+                        let Ok(cmd) = serde_json::from_str::<serde_json::Value>(&cmd) else {
+                            return Err(LockError::BadLockFile { path });
+                        };
+                        return Err(LockError::Locked {
+                            pid: cmd["pid"].as_u64().unwrap() as u32,
+                            cmd: cmd["cmd"].as_str().unwrap().to_string(),
+                        });
+                    }
+                    return Err(LockError::BadLockFile { path });
+                }
+                continue;
+            }
+        }
+    }
+}
+
+async fn try_create_lock_loop_async(
+    lock_type: file_guard::Lock,
+    path: PathBuf,
+) -> Result<LockInner, LockError> {
+    let start = Instant::now();
+    let mut warned = false;
+    let mut first = true;
+
+    loop {
+        match try_create_lock(lock_type.clone(), path.clone()) {
+            Ok(lock) => return Ok(lock),
+            Err(e) => {
+                if first {
+                    if let Ok(cmd) = std::fs::read_to_string(&path) {
+                        let Ok(cmd) = serde_json::from_str::<serde_json::Value>(&cmd) else {
+                            return Err(LockError::BadLockFile { path });
+                        };
+                        warn!(
+                            "Waiting for lock held by process {pid} running {cmd:?}",
+                            pid = cmd["pid"].as_u64().unwrap() as u32,
+                            cmd = cmd["cmd"].as_str().unwrap().to_string()
+                        );
+                    }
+                    first = false;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                if start.elapsed() > SLOW_LOCK_WARNING {
+                    if !warned {
+                        warn!("Still waiting for lock");
+                        warned = true;
+                    }
+                }
+                if start.elapsed() > SLOW_LOCK_TIMEOUT {
+                    if let Ok(cmd) = std::fs::read_to_string(&path) {
+                        let Ok(cmd) = serde_json::from_str::<serde_json::Value>(&cmd) else {
+                            return Err(LockError::BadLockFile { path });
+                        };
+                    }
+                }
+            }
+        }
+    }
 }
 
 fn instance_lock_path(instance: &InstanceName) -> Option<PathBuf> {
@@ -103,8 +206,11 @@ fn instance_lock_path(instance: &InstanceName) -> Option<PathBuf> {
         return None;
     };
 
-    std::fs::create_dir_all(&paths.runstate_path).unwrap();
-    let lock_path = paths.runstate_path.join("lock.cli");
+    if let Some(parent) = paths.data_dir.parent() {
+        _ = std::fs::create_dir_all(parent);
+    }
+    let mut lock_path = paths.data_dir.clone();
+    lock_path.set_extension(LOCK_FILE_NAME);
     Some(lock_path)
 }
 
@@ -112,68 +218,97 @@ impl LockManager {
     pub fn lock_instance(instance: &InstanceName) -> Result<InstanceLock, LockError> {
         let Some(lock_path) = instance_lock_path(instance) else {
             return Ok(InstanceLock {
-                inner: Arc::new(InstanceLockInner::NoLock),
+                inner: Arc::new(LockInner::NoLock),
             });
         };
 
-        loop {
-            match try_create_lock(lock_path.clone()) {
-                Ok(lock) => {
-                    return Ok(InstanceLock {
-                        inner: Arc::new(lock),
-                    });
-                }
-                Err(e) => {
-                    std::thread::sleep(std::time::Duration::from_millis(100));
-                    continue;
-                }
-            }
-        }
+        Ok(InstanceLock {
+            inner: Arc::new(try_create_lock_loop_sync(
+                file_guard::Lock::Exclusive,
+                lock_path,
+            )?),
+        })
     }
 
-    pub fn lock_read_instance(
-        instance: &impl Into<InstanceName>,
-    ) -> Result<InstanceLock, LockError> {
+    pub fn lock_read_instance(instance: &InstanceName) -> Result<InstanceLock, LockError> {
+        let Some(lock_path) = instance_lock_path(instance) else {
+            return Ok(InstanceLock {
+                inner: Arc::new(LockInner::NoLock),
+            });
+        };
+
         Ok(InstanceLock {
-            inner: Arc::new(InstanceLockInner::NoLock),
+            inner: Arc::new(try_create_lock_loop_sync(
+                file_guard::Lock::Shared,
+                lock_path,
+            )?),
         })
     }
 
     pub async fn lock_instance_async(instance: &InstanceName) -> Result<InstanceLock, LockError> {
         let Some(lock_path) = instance_lock_path(instance) else {
             return Ok(InstanceLock {
-                inner: Arc::new(InstanceLockInner::NoLock),
+                inner: Arc::new(LockInner::NoLock),
             });
         };
 
-        loop {
-            match try_create_lock(lock_path.clone()) {
-                Ok(lock) => {
-                    return Ok(InstanceLock {
-                        inner: Arc::new(lock),
-                    });
-                }
-                Err(e) => {
-                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                    continue;
-                }
-            }
-        }
+        Ok(InstanceLock {
+            inner: Arc::new(
+                try_create_lock_loop_async(file_guard::Lock::Exclusive, lock_path).await?,
+            ),
+        })
     }
 
     pub async fn lock_read_instance_async(
-        instance: &impl Into<InstanceName>,
+        instance: &InstanceName,
     ) -> Result<InstanceLock, LockError> {
+        let Some(lock_path) = instance_lock_path(instance) else {
+            return Ok(InstanceLock {
+                inner: Arc::new(LockInner::NoLock),
+            });
+        };
+
         Ok(InstanceLock {
-            inner: Arc::new(InstanceLockInner::NoLock),
+            inner: Arc::new(try_create_lock_loop_async(file_guard::Lock::Shared, lock_path).await?),
         })
     }
 
     pub fn lock_project(path: impl AsRef<Path>) -> Result<ProjectLock, LockError> {
-        Ok(ProjectLock {})
+        let Ok(stash_path) = get_stash_path(path.as_ref()) else {
+            return Ok(ProjectLock {
+                inner: Arc::new(LockInner::NoLock),
+            });
+        };
+        if !stash_path.exists() {
+            return Ok(ProjectLock {
+                inner: Arc::new(LockInner::NoLock),
+            });
+        }
+        let lock_path = stash_path.join(LOCK_FILE_NAME);
+        Ok(ProjectLock {
+            inner: Arc::new(try_create_lock_loop_sync(
+                file_guard::Lock::Exclusive,
+                lock_path,
+            )?),
+        })
     }
 
     pub async fn lock_project_async(path: impl AsRef<Path>) -> Result<ProjectLock, LockError> {
-        Ok(ProjectLock {})
+        let Ok(stash_path) = get_stash_path(path.as_ref()) else {
+            return Ok(ProjectLock {
+                inner: Arc::new(LockInner::NoLock),
+            });
+        };
+        if !stash_path.exists() {
+            return Ok(ProjectLock {
+                inner: Arc::new(LockInner::NoLock),
+            });
+        }
+        let lock_path = stash_path.join(LOCK_FILE_NAME);
+        Ok(ProjectLock {
+            inner: Arc::new(
+                try_create_lock_loop_async(file_guard::Lock::Exclusive, lock_path).await?,
+            ),
+        })
     }
 }

--- a/src/locking.rs
+++ b/src/locking.rs
@@ -1,10 +1,8 @@
-use std::{
-    fs::{File, OpenOptions},
-    io::Write,
-    path::{Path, PathBuf},
-    sync::{Arc, atomic::AtomicBool},
-    time::{Duration, Instant},
-};
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, atomic::AtomicBool};
+use std::time::{Duration, Instant};
 
 use gel_tokio::InstanceName;
 use log::{debug, warn};
@@ -18,24 +16,18 @@ const SLOW_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone)]
 pub struct InstanceLock {
+    #[allow(unused)]
     inner: Arc<LockInner>,
 }
 
-impl InstanceLock {
-    /// Notify the lock that it will be removed externally.
-    pub fn lock_will_be_removed(&self) {
-        if let LockInner::Local(_, _, must_exist) = &*self.inner {
-            must_exist.store(false, std::sync::atomic::Ordering::Relaxed);
-        }
-    }
-}
+impl InstanceLock {}
 
 #[derive(Debug)]
 enum LockInner {
     NoLock,
     Local(
         PathBuf,
-        Option<file_guard::FileGuard<Arc<File>>>,
+        Option<file_guard::FileGuard<Box<File>>>,
         AtomicBool,
     ),
 }
@@ -57,6 +49,7 @@ impl Drop for LockInner {
 
 #[derive(Debug, Clone)]
 pub struct ProjectLock {
+    #[allow(unused)]
     inner: Arc<LockInner>,
 }
 
@@ -76,114 +69,145 @@ pub enum LockError {
 }
 
 fn try_create_lock(lock_type: file_guard::Lock, path: PathBuf) -> Result<LockInner, LockError> {
-    let mut lock_file = OpenOptions::new()
+    let lock_file = OpenOptions::new()
         .create(true)
-        .truncate(true)
         .write(true)
         .open(&path)
-        .unwrap();
-    lock_file.write_all(
-        json!({"pid": std::process::id(), "cmd": std::env::args().collect::<Vec<_>>().join(" ")})
-            .to_string()
-            .as_bytes(),
-    ).map_err(|e| LockError::IOError { path: path.clone(), error: e })?;
-    let lock_file = Arc::new(lock_file);
-    let lock =
+        .map_err(|e| LockError::IOError {
+            path: path.clone(),
+            error: e,
+        })?;
+    let lock_file = Box::new(lock_file);
+    let mut lock =
         file_guard::try_lock(lock_file, lock_type, 0, 1).map_err(|e| LockError::IOError {
             path: path.clone(),
             error: e,
         })?;
+
+    lock.set_len(0).map_err(|e| LockError::IOError {
+        path: path.clone(),
+        error: e,
+    })?;
+    lock.write_all(
+        json!({"pid": std::process::id(), "cmd": std::env::args().collect::<Vec<_>>().join(" ")})
+            .to_string()
+            .as_bytes(),
+    )
+    .map_err(|e| LockError::IOError {
+        path: path.clone(),
+        error: e,
+    })?;
+    lock.flush().map_err(|e| LockError::IOError {
+        path: path.clone(),
+        error: e,
+    })?;
+
     debug!("Lock created: {path:?}");
     Ok(LockInner::Local(path, Some(lock), AtomicBool::new(true)))
 }
 
-fn try_create_lock_loop_sync(
-    lock_type: file_guard::Lock,
+struct LoopState {
+    start: Instant,
+    warned: bool,
+    first: bool,
     path: PathBuf,
-) -> Result<LockInner, LockError> {
-    let start = Instant::now();
-    let mut warned = false;
-    let mut first = true;
-    loop {
-        match try_create_lock(lock_type, path.clone()) {
-            Ok(lock) => return Ok(lock),
-            Err(e) => {
-                if first {
-                    if let Ok(cmd) = std::fs::read_to_string(&path) {
-                        let Ok(cmd) = serde_json::from_str::<serde_json::Value>(&cmd) else {
-                            return Err(LockError::BadLockFile { path });
-                        };
-                        warn!(
-                            "Waiting for lock held by process {pid} running {cmd:?}",
-                            pid = cmd["pid"].as_u64().unwrap() as u32,
-                            cmd = cmd["cmd"].as_str().unwrap().to_string()
-                        );
-                    }
-                    first = false;
+}
+
+impl LoopState {
+    fn new(path: PathBuf) -> Self {
+        Self {
+            start: Instant::now(),
+            warned: false,
+            first: true,
+            path,
+        }
+    }
+
+    fn load_lock_file(&self) -> Result<(u32, String), LockError> {
+        let cmd = std::fs::read_to_string(&self.path).map_err(|e| LockError::IOError {
+            path: self.path.clone(),
+            error: e,
+        })?;
+        let cmd: serde_json::Value =
+            serde_json::from_str(&cmd).map_err(|_| LockError::BadLockFile {
+                path: self.path.clone(),
+            })?;
+        let pid = cmd["pid"].as_u64().ok_or(LockError::BadLockFile {
+            path: self.path.clone(),
+        })? as u32;
+        let cmd = cmd["cmd"]
+            .as_str()
+            .ok_or(LockError::BadLockFile {
+                path: self.path.clone(),
+            })?
+            .to_string();
+        Ok((pid, cmd))
+    }
+
+    fn error(&mut self, _e: LockError) -> Result<(), LockError> {
+        if self.first {
+            self.first = false;
+        }
+
+        if self.first {
+            if let Ok((pid, cmd)) = self.load_lock_file() {
+                warn!("Waiting for lock held by process {pid} running {cmd:?}",);
+            } else {
+                warn!("Waiting for lock ({})", self.path.display());
+            }
+            self.first = false;
+        }
+        if self.start.elapsed() > SLOW_LOCK_WARNING {
+            if !self.warned {
+                if let Ok((pid, cmd)) = self.load_lock_file() {
+                    warn!("Still waiting for lock held by process {pid} running {cmd:?}",);
+                } else {
+                    warn!("Still waiting for lock ({})", self.path.display());
                 }
-                std::thread::sleep(std::time::Duration::from_millis(100));
-                if start.elapsed() > SLOW_LOCK_WARNING {
-                    if !warned {
-                        warn!("Still waiting for lock ({path:?})");
-                        warned = true;
-                    }
+                self.warned = true;
+            }
+        }
+        if self.start.elapsed() > SLOW_LOCK_TIMEOUT {
+            if let Ok((pid, cmd)) = self.load_lock_file() {
+                return Err(LockError::Locked { pid, cmd });
+            }
+            return Err(LockError::BadLockFile {
+                path: self.path.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    fn try_create_lock_loop_sync(
+        lock_type: file_guard::Lock,
+        path: PathBuf,
+    ) -> Result<LockInner, LockError> {
+        let mut state = LoopState::new(path.clone());
+        loop {
+            match try_create_lock(lock_type, path.clone()) {
+                Ok(lock) => return Ok(lock),
+                Err(e) => {
+                    state.error(e)?;
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                    continue;
                 }
-                if start.elapsed() > SLOW_LOCK_TIMEOUT {
-                    if let Ok(cmd) = std::fs::read_to_string(&path) {
-                        let Ok(cmd) = serde_json::from_str::<serde_json::Value>(&cmd) else {
-                            return Err(LockError::BadLockFile { path });
-                        };
-                        return Err(LockError::Locked {
-                            pid: cmd["pid"].as_u64().unwrap() as u32,
-                            cmd: cmd["cmd"].as_str().unwrap().to_string(),
-                        });
-                    }
-                    return Err(LockError::BadLockFile { path });
-                }
-                continue;
             }
         }
     }
-}
 
-async fn try_create_lock_loop_async(
-    lock_type: file_guard::Lock,
-    path: PathBuf,
-) -> Result<LockInner, LockError> {
-    let start = Instant::now();
-    let mut warned = false;
-    let mut first = true;
+    async fn try_create_lock_loop_async(
+        lock_type: file_guard::Lock,
+        path: PathBuf,
+    ) -> Result<LockInner, LockError> {
+        let mut state = LoopState::new(path.clone());
 
-    loop {
-        match try_create_lock(lock_type.clone(), path.clone()) {
-            Ok(lock) => return Ok(lock),
-            Err(e) => {
-                if first {
-                    if let Ok(cmd) = std::fs::read_to_string(&path) {
-                        let Ok(cmd) = serde_json::from_str::<serde_json::Value>(&cmd) else {
-                            return Err(LockError::BadLockFile { path });
-                        };
-                        warn!(
-                            "Waiting for lock held by process {pid} running {cmd:?}",
-                            pid = cmd["pid"].as_u64().unwrap() as u32,
-                            cmd = cmd["cmd"].as_str().unwrap().to_string()
-                        );
-                    }
-                    first = false;
-                }
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                if start.elapsed() > SLOW_LOCK_WARNING {
-                    if !warned {
-                        warn!("Still waiting for lock");
-                        warned = true;
-                    }
-                }
-                if start.elapsed() > SLOW_LOCK_TIMEOUT {
-                    if let Ok(cmd) = std::fs::read_to_string(&path) {
-                        let Ok(cmd) = serde_json::from_str::<serde_json::Value>(&cmd) else {
-                            return Err(LockError::BadLockFile { path });
-                        };
-                    }
+        loop {
+            match try_create_lock(lock_type.clone(), path.clone()) {
+                Ok(lock) => return Ok(lock),
+                Err(e) => {
+                    state.error(e)?;
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    continue;
                 }
             }
         }
@@ -223,7 +247,7 @@ impl LockManager {
         };
 
         Ok(InstanceLock {
-            inner: Arc::new(try_create_lock_loop_sync(
+            inner: Arc::new(LoopState::try_create_lock_loop_sync(
                 file_guard::Lock::Exclusive,
                 lock_path,
             )?),
@@ -238,7 +262,7 @@ impl LockManager {
         };
 
         Ok(InstanceLock {
-            inner: Arc::new(try_create_lock_loop_sync(
+            inner: Arc::new(LoopState::try_create_lock_loop_sync(
                 file_guard::Lock::Shared,
                 lock_path,
             )?),
@@ -254,7 +278,8 @@ impl LockManager {
 
         Ok(InstanceLock {
             inner: Arc::new(
-                try_create_lock_loop_async(file_guard::Lock::Exclusive, lock_path).await?,
+                LoopState::try_create_lock_loop_async(file_guard::Lock::Exclusive, lock_path)
+                    .await?,
             ),
         })
     }
@@ -269,7 +294,9 @@ impl LockManager {
         };
 
         Ok(InstanceLock {
-            inner: Arc::new(try_create_lock_loop_async(file_guard::Lock::Shared, lock_path).await?),
+            inner: Arc::new(
+                LoopState::try_create_lock_loop_async(file_guard::Lock::Shared, lock_path).await?,
+            ),
         })
     }
 
@@ -286,7 +313,7 @@ impl LockManager {
         }
         let lock_path = stash_path.join(LOCK_FILE_NAME);
         Ok(ProjectLock {
-            inner: Arc::new(try_create_lock_loop_sync(
+            inner: Arc::new(LoopState::try_create_lock_loop_sync(
                 file_guard::Lock::Exclusive,
                 lock_path,
             )?),
@@ -307,7 +334,8 @@ impl LockManager {
         let lock_path = stash_path.join(LOCK_FILE_NAME);
         Ok(ProjectLock {
             inner: Arc::new(
-                try_create_lock_loop_async(file_guard::Lock::Exclusive, lock_path).await?,
+                LoopState::try_create_lock_loop_async(file_guard::Lock::Exclusive, lock_path)
+                    .await?,
             ),
         })
     }

--- a/src/locking.rs
+++ b/src/locking.rs
@@ -43,13 +43,16 @@ impl Drop for LockInner {
                 // we can.
                 debug!("Dropping lock: {path:?}, shared: {shared}");
                 if shared {
-                    if cfg!(unix) {
+                    #[cfg(unix)]
+                    {
                         use file_guard::os::unix::FileGuardExt;
                         if lock.try_upgrade().is_ok() {
                             debug!("Removed shared lock file {path:?}");
                             _ = std::fs::remove_file(&path);
                         }
-                    } else {
+                    }
+
+                    if !cfg!(unix) {
                         drop(lock);
                         if let Ok(file) = OpenOptions::new().write(true).open(&path) {
                             if let Ok(lock) = file_guard::try_lock(

--- a/src/locking.rs
+++ b/src/locking.rs
@@ -1,0 +1,138 @@
+use std::{fs::{File, OpenOptions}, io::Write, path::{Path, PathBuf}, sync::Arc};
+
+use gel_tokio::{dsn::StoredInformation, InstanceName};
+use log::warn;
+use serde_json::json;
+
+struct Lock {}
+
+#[derive(Debug, Clone)]
+pub struct InstanceLock {
+    inner: Arc<InstanceLockInner>,
+}
+
+#[derive(Debug)]
+enum InstanceLockInner {
+    NoLock,
+    Local(PathBuf, Option<file_guard::FileGuard<Arc<File>>>),
+}
+
+impl Drop for InstanceLockInner {
+    fn drop(&mut self) {
+        if let InstanceLockInner::Local(path,lock) = self {
+            if let Some(lock) = lock.take() {
+                drop(lock);
+                if let Err(e) = std::fs::remove_file(&path) {
+                    warn!("Failed to remove lock file {path:?}: {e}");
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ProjectLock {}
+
+pub struct LockManager {}
+
+#[derive(thiserror::Error, Debug)]
+pub enum LockError {
+}
+
+struct LockManagerInstance {
+}
+
+impl LockManagerInstance {
+    pub fn new() {
+    }
+}
+
+fn try_create_lock(path: PathBuf) -> Result<InstanceLockInner, LockError> {
+    let mut lock_file = OpenOptions::new().create(true).truncate(true).write(true).open(&path).unwrap();
+    lock_file.write_all(json!({"pid": std::process::id(), "cmd": std::env::args().collect::<Vec<_>>()}).to_string().as_bytes()).unwrap();
+    let lock_file = Arc::new(lock_file);
+    let lock = file_guard::lock(lock_file, file_guard::Lock::Exclusive, 0, 1).unwrap();
+    Ok(InstanceLockInner::Local(path, Some(lock)))
+}
+
+fn instance_lock_path(instance: &InstanceName) -> Option<PathBuf> {
+    let instance = instance.clone().into();
+    let InstanceName::Local(local_name) = &instance else {
+        return None;
+    };
+    
+    let Some(paths) = gel_tokio::Builder::new().with_system().stored_info().paths().for_instance(&local_name) else {
+        warn!("Unable to find instance path to lock");
+        return None;
+    };
+
+    std::fs::create_dir_all(&paths.runstate_path).unwrap();
+    let lock_path = paths.runstate_path.join("lock.cli");
+    Some(lock_path)
+}
+
+impl LockManager {
+    pub fn lock_instance(instance: &InstanceName) -> Result<InstanceLock, LockError> {
+        let Some(lock_path) = instance_lock_path(instance) else {
+            return Ok(InstanceLock {
+                inner: Arc::new(InstanceLockInner::NoLock),
+            });
+        };
+
+        loop {
+            match try_create_lock(lock_path.clone()) {
+                Ok(lock) => {
+                    return Ok(InstanceLock {
+                        inner: Arc::new(lock),
+                    });
+                }
+                Err(e) => {
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                    continue;
+                }
+            }
+        }
+    }
+
+    pub fn lock_read_instance(instance: &impl Into<InstanceName>) -> Result<InstanceLock, LockError> {
+        Ok(InstanceLock {
+            inner: Arc::new(InstanceLockInner::NoLock),
+        })
+    }
+
+    pub async fn lock_instance_async(instance: &InstanceName) -> Result<InstanceLock, LockError> {
+        let Some(lock_path) = instance_lock_path(instance) else {
+            return Ok(InstanceLock {
+                inner: Arc::new(InstanceLockInner::NoLock),
+            });
+        };
+
+        loop {
+            match try_create_lock(lock_path.clone()) {
+                Ok(lock) => {
+                    return Ok(InstanceLock {
+                        inner: Arc::new(lock),
+                    });
+                }
+                Err(e) => {
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    continue;
+                }
+            }
+        }
+    }
+
+    pub async fn lock_read_instance_async(instance: &impl Into<InstanceName>) -> Result<InstanceLock, LockError> {
+        Ok(InstanceLock {
+            inner: Arc::new(InstanceLockInner::NoLock),
+        })
+    }
+
+    pub fn lock_project(path: impl AsRef<Path>) -> Result<ProjectLock, LockError> {
+        Ok(ProjectLock {})
+    }
+
+    pub async fn lock_project_async(path: impl AsRef<Path>) -> Result<ProjectLock, LockError> {
+        Ok(ProjectLock {})
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ mod hint;
 mod hooks;
 mod interactive;
 mod interrupt;
+mod locking;
 mod log_levels;
 mod markdown;
 mod migrations;

--- a/src/migrations/apply.rs
+++ b/src/migrations/apply.rs
@@ -87,7 +87,8 @@ async fn run_inner(
     conn: &mut Connection,
     options: &Options,
 ) -> Result<(), anyhow::Error> {
-    let ctx = Context::for_migration_config(&cmd.cfg, cmd.quiet, options.skip_hooks).await?;
+    // migrate apply needs to be able to run during gel watch.
+    let ctx = Context::for_migration_config(&cmd.cfg, cmd.quiet, options.skip_hooks, true).await?;
     if cmd.dev_mode {
         let bar = if cmd.quiet {
             ProgressBar::hidden()

--- a/src/migrations/context.rs
+++ b/src/migrations/context.rs
@@ -21,6 +21,7 @@ impl Context {
         cfg: &MigrationConfig,
         quiet: bool,
         skip_hooks: bool,
+        read_only: bool,
     ) -> anyhow::Result<Context> {
         let project = project::load_ctx(None).await?;
 
@@ -43,7 +44,10 @@ impl Context {
             let stash_path = get_stash_path(&project.location.root)?;
             if stash_path.exists() {
                 let instance_name = instance_name(&stash_path)?;
-                instance_lock = Some(LockManager::lock_instance(&instance_name)?);
+                instance_lock = Some(LockManager::lock_maybe_read_instance(
+                    &instance_name,
+                    read_only,
+                )?);
             }
         }
 

--- a/src/migrations/context.rs
+++ b/src/migrations/context.rs
@@ -12,6 +12,7 @@ pub struct Context {
 
     pub project: Option<project::Context>,
 
+    #[allow(unused)]
     instance_lock: Option<InstanceLock>,
 }
 

--- a/src/migrations/context.rs
+++ b/src/migrations/context.rs
@@ -23,7 +23,7 @@ impl Context {
         skip_hooks: bool,
         read_only: bool,
     ) -> anyhow::Result<Context> {
-        let project = project::load_ctx(None).await?;
+        let project = project::load_ctx(None, read_only).await?;
 
         let schema_dir = if let Some(schema_dir) = &cfg.schema_dir {
             schema_dir.clone()

--- a/src/migrations/context.rs
+++ b/src/migrations/context.rs
@@ -1,5 +1,6 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
+use crate::locking::{InstanceLock, ProjectLock};
 use crate::migrations::options::MigrationConfig;
 use crate::portable::project;
 
@@ -10,6 +11,9 @@ pub struct Context {
     pub skip_hooks: bool,
 
     pub project: Option<project::Context>,
+
+    instance_lock: Option<InstanceLock>,
+    project_lock: Option<ProjectLock>,
 }
 
 impl Context {
@@ -39,6 +43,8 @@ impl Context {
             quiet,
             project,
             skip_hooks,
+            instance_lock: None,
+            project_lock: None,
         })
     }
     pub fn for_project(project: project::Context, skip_hooks: bool) -> anyhow::Result<Context> {
@@ -51,6 +57,21 @@ impl Context {
             quiet: false,
             skip_hooks,
             project: Some(project),
+            instance_lock: None,
+            project_lock: None,
+        })
+    }
+    /// Create a context for a temporary path.
+    ///
+    /// Hooks are skipped.
+    pub fn for_temp_path(path: impl AsRef<Path>) -> anyhow::Result<Context> {
+        Ok(Context {
+            schema_dir: path.as_ref().to_path_buf(),
+            quiet: false,
+            skip_hooks: true,
+            project: None,
+            instance_lock: None,
+            project_lock: None,
         })
     }
 }

--- a/src/migrations/create.rs
+++ b/src/migrations/create.rs
@@ -1051,12 +1051,7 @@ async fn start_migration() {
     let mut schema_dir = env::current_dir().unwrap();
     schema_dir.push("tests/migrations/db5");
 
-    let ctx = Context {
-        schema_dir,
-        quiet: false,
-        project: None,
-        skip_hooks: true,
-    };
+    let ctx = Context::for_temp_path(schema_dir).unwrap();
 
     let res = gen_start_migration(&ctx).await.unwrap();
 

--- a/src/migrations/create.rs
+++ b/src/migrations/create.rs
@@ -85,7 +85,7 @@ pub struct Command {
 }
 
 async fn run_inner(cmd: &Command, conn: &mut Connection, options: &Options) -> anyhow::Result<()> {
-    let ctx = Context::for_migration_config(&cmd.cfg, false, options.skip_hooks).await?;
+    let ctx = Context::for_migration_config(&cmd.cfg, false, options.skip_hooks, true).await?;
 
     if dev_mode::check_client(conn).await? {
         let dev_num = query_row::<i64>(

--- a/src/migrations/edit.rs
+++ b/src/migrations/edit.rs
@@ -70,7 +70,7 @@ fn print_diff(path1: &Path, data1: &str, path2: &Path, data2: &str) {
 
 #[tokio::main(flavor = "current_thread")]
 pub async fn edit_no_check(cmd: &MigrationEdit, opts: &Options) -> Result<(), anyhow::Error> {
-    let ctx = Context::for_migration_config(&cmd.cfg, false, opts.skip_hooks).await?;
+    let ctx = Context::for_migration_config(&cmd.cfg, false, opts.skip_hooks, false).await?;
     // TODO(tailhook) do we have to make the full check of whether there are no
     // gaps and parent revisions are okay?
     let (_n, path) = read_names(&ctx)
@@ -128,7 +128,7 @@ pub async fn edit(cli: &mut Connection, cmd: &MigrationEdit, opts: &Options) -> 
 }
 
 async fn _edit(cli: &mut Connection, cmd: &MigrationEdit, opts: &Options) -> anyhow::Result<()> {
-    let ctx = Context::for_migration_config(&cmd.cfg, false, opts.skip_hooks).await?;
+    let ctx = Context::for_migration_config(&cmd.cfg, false, opts.skip_hooks, false).await?;
     // TODO(tailhook) do we have to make the full check of whether there are no
     // gaps and parent revisions are okay?
     let (n, path) = cli

--- a/src/migrations/extract.rs
+++ b/src/migrations/extract.rs
@@ -54,12 +54,7 @@ pub async fn extract(
     let migrations = db_migration::read_all(cli, true, false).await?;
     let mut db_iter = migrations.into_iter().enumerate();
     let temp_dir = tempfile::tempdir()?;
-    let temp_ctx = Context {
-        schema_dir: temp_dir.path().to_path_buf(),
-        quiet: false,
-        project: None,
-        skip_hooks: true,
-    };
+    let temp_ctx = Context::for_temp_path(temp_dir.path())?;
     let mut to_delete = Vec::new();
 
     loop {

--- a/src/migrations/extract.rs
+++ b/src/migrations/extract.rs
@@ -47,7 +47,8 @@ pub async fn extract(
     opts: &Options,
 ) -> anyhow::Result<()> {
     let src_ctx =
-        Context::for_migration_config(&cmd.cfg, cmd.non_interactive, opts.skip_hooks).await?;
+        Context::for_migration_config(&cmd.cfg, cmd.non_interactive, opts.skip_hooks, false)
+            .await?;
     let current = migration::read_all(&src_ctx, false).await?;
     let mut disk_iter = current.into_iter();
 

--- a/src/migrations/log.rs
+++ b/src/migrations/log.rs
@@ -48,7 +48,7 @@ pub async fn log_fs(cmd: &MigrationLog, opts: &Options) -> Result<(), anyhow::Er
 async fn log_fs_async(cmd: &MigrationLog, opts: &Options) -> Result<(), anyhow::Error> {
     assert!(cmd.from_fs);
 
-    let ctx = Context::for_migration_config(&cmd.cfg, false, opts.skip_hooks).await?;
+    let ctx = Context::for_migration_config(&cmd.cfg, false, opts.skip_hooks, true).await?;
     let migrations = migration::read_all(&ctx, true).await?;
     print(&migrations, cmd);
     Ok(())

--- a/src/migrations/merge.rs
+++ b/src/migrations/merge.rs
@@ -150,12 +150,7 @@ pub async fn write_merge_migrations(
     migrations: &mut MergeMigrations,
 ) -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
-    let temp_ctx = Context {
-        schema_dir: temp_dir.path().to_path_buf(),
-        quiet: false,
-        project: None,
-        skip_hooks: true,
-    };
+    let temp_ctx = Context::for_temp_path(temp_dir.path())?;
 
     for (_, migration) in migrations.flatten() {
         write_migration(&temp_ctx, migration, false).await?;

--- a/src/migrations/rebase.rs
+++ b/src/migrations/rebase.rs
@@ -255,12 +255,7 @@ pub async fn do_rebase(
     context: &Context,
 ) -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
-    let temp_ctx = Context {
-        schema_dir: temp_dir.path().to_path_buf(),
-        quiet: false,
-        project: None,
-        skip_hooks: true,
-    };
+    let temp_ctx = Context::for_temp_path(temp_dir.path())?;
 
     // write all the migrations to disk.
     let to_flatten = rebase_migrations.clone();

--- a/src/migrations/squash.rs
+++ b/src/migrations/squash.rs
@@ -27,7 +27,8 @@ pub async fn run(
     conn: &mut Connection,
     opts: &Options,
 ) -> anyhow::Result<()> {
-    let ctx = Context::for_migration_config(&cmd.cfg, cmd.non_interactive, opts.skip_hooks).await?;
+    let ctx = Context::for_migration_config(&cmd.cfg, cmd.non_interactive, opts.skip_hooks, false)
+        .await?;
     let migrations = migration::read_all(&ctx, true).await?;
     let Some(db_rev) = migrations_applied(conn, &ctx, &migrations).await? else {
         return Err(ExitCode::new(3).into());

--- a/src/migrations/squash.rs
+++ b/src/migrations/squash.rs
@@ -303,12 +303,7 @@ async fn test_two_stage_remove() -> anyhow::Result<()> {
     // show up on tmpfs!
     let tmp = tempfile::tempdir_in(".")?;
 
-    let ctx = Context {
-        schema_dir: tmp.path().to_path_buf(),
-        quiet: false,
-        project: None,
-        skip_hooks: true,
-    };
+    let ctx = Context::for_temp_path(tmp.path())?;
 
     // Create test migration files
     let migrations_dir = tmp.path().join("migrations");

--- a/src/migrations/status.rs
+++ b/src/migrations/status.rs
@@ -47,7 +47,7 @@ pub async fn status(
     cmd: &ShowStatus,
     opts: &Options,
 ) -> Result<(), anyhow::Error> {
-    let ctx = Context::for_migration_config(&cmd.cfg, cmd.quiet, opts.skip_hooks).await?;
+    let ctx = Context::for_migration_config(&cmd.cfg, cmd.quiet, opts.skip_hooks, true).await?;
     let migrations = migration::read_all(&ctx, true).await?;
     match up_to_date_check(cli, &ctx, &migrations).await? {
         Some(_) if cmd.quiet => Ok(()),

--- a/src/migrations/upgrade_check.rs
+++ b/src/migrations/upgrade_check.rs
@@ -59,7 +59,7 @@ pub fn upgrade_check(_options: &Options, options: &UpgradeCheck) -> anyhow::Resu
                     break;
                 }
             }
-            let ctx = Context::for_migration_config(&options.cfg, false, true).await?;
+            let ctx = Context::for_migration_config(&options.cfg, false, true, true).await?;
 
             Box::pin(do_check(
                 &ctx,

--- a/src/migrations/upgrade_check.rs
+++ b/src/migrations/upgrade_check.rs
@@ -112,7 +112,12 @@ pub fn upgrade_check(_options: &Options, options: &UpgradeCheck) -> anyhow::Resu
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
-    let ctx = runtime.block_on(Context::for_migration_config(&options.cfg, false, true))?;
+    let ctx = runtime.block_on(Context::for_migration_config(
+        &options.cfg,
+        false,
+        true,
+        true,
+    ))?;
 
     let mut watch_options = WatchOptions::default();
     if !options.no_exit_with_parent {

--- a/src/migrations/upgrade_format.rs
+++ b/src/migrations/upgrade_format.rs
@@ -13,7 +13,7 @@ pub async fn upgrade_format(
     cmd: &MigrationUpgradeFormat,
     opts: &Options,
 ) -> anyhow::Result<()> {
-    let ctx = Context::for_migration_config(&cmd.cfg, false, opts.skip_hooks).await?;
+    let ctx = Context::for_migration_config(&cmd.cfg, false, opts.skip_hooks, false).await?;
 
     _upgrade_format(&ctx).await
 }

--- a/src/migrations/upgrade_format.rs
+++ b/src/migrations/upgrade_format.rs
@@ -74,12 +74,7 @@ mod test {
         fs_extra::dir::copy(original_schema_dir, &tmp_dir, &Default::default()).unwrap();
         let schema_dir = tmp_dir.path().to_path_buf();
 
-        let ctx = Context {
-            schema_dir,
-            quiet: false,
-            project: None,
-            skip_hooks: true,
-        };
+        let ctx = Context::for_temp_path(schema_dir).unwrap();
 
         _upgrade_format(&ctx).await.unwrap();
 

--- a/src/portable/exit_codes.rs
+++ b/src/portable/exit_codes.rs
@@ -6,3 +6,4 @@ pub const INVALID_CONFIG: i32 = 4;
 pub const NOT_CONFIRMED: i32 = 6;
 pub const PARTIAL_SUCCESS: i32 = 7;
 pub const INSTANCE_NOT_FOUND: i32 = 8;
+pub const LOCK_ERROR: i32 = 9;

--- a/src/portable/instance/backup.rs
+++ b/src/portable/instance/backup.rs
@@ -12,6 +12,7 @@ use gel_tokio::InstanceName;
 
 use crate::branding::BRANDING_CLI_CMD;
 use crate::cloud;
+use crate::locking::LockManager;
 use crate::options::CloudOptions;
 use crate::portable::local::InstanceInfo;
 use crate::print::msg;
@@ -139,6 +140,7 @@ pub async fn list(cmd: &ListBackups, opts: &crate::options::Options) -> anyhow::
         bail!("Instance backup/restore is not yet supported on Windows");
     }
 
+    let _lock = LockManager::lock_read_instance_async(&cmd.instance).await?;
     let instance = get_instance(opts, &cmd.instance)?.backup()?;
     let backups = instance.list_backups().await?;
 
@@ -184,6 +186,7 @@ pub async fn backup(cmd: &Backup, opts: &crate::options::Options) -> anyhow::Res
     }
 
     let inst_name = cmd.instance.clone();
+    let _lock = LockManager::lock_read_instance_async(&inst_name).await?;
     let backup = get_instance(opts, &cmd.instance)?.backup()?;
 
     let prompt = format!(
@@ -240,6 +243,7 @@ pub async fn restore(cmd: &Restore, opts: &crate::options::Options) -> anyhow::R
     }
 
     let inst_name = cmd.instance.clone();
+    let _lock = LockManager::lock_instance_async(&inst_name).await?;
     let backup = get_instance(opts, &cmd.instance)?.backup()?;
 
     let stop_warning = if let InstanceName::Local(_) = &cmd.instance {

--- a/src/portable/instance/control.rs
+++ b/src/portable/instance/control.rs
@@ -12,6 +12,7 @@ use crate::bug;
 use crate::commands::ExitCode;
 use crate::credentials;
 use crate::hint::HintExt;
+use crate::locking::LockManager;
 use crate::options::{InstanceOptions, InstanceOptionsLegacy};
 use crate::platform::current_exe;
 use crate::portable::local::{InstanceInfo, lock_file, open_lock, runstate_dir};
@@ -288,6 +289,8 @@ fn set_inheritable(file: &impl std::os::unix::io::AsRawFd) -> anyhow::Result<()>
 }
 
 pub fn start(options: &Start) -> anyhow::Result<()> {
+    let _lock = LockManager::lock_instance(&options.instance_opts.instance_allow_legacy()?)?;
+
     // Special case: instance name is allowed to be positional for start, because start
     // is used in systemd services and cannot be changed.
     // Maybe we should make "fixup" that updates those services?

--- a/src/portable/instance/control.rs
+++ b/src/portable/instance/control.rs
@@ -12,7 +12,6 @@ use crate::bug;
 use crate::commands::ExitCode;
 use crate::credentials;
 use crate::hint::HintExt;
-use crate::locking::LockManager;
 use crate::options::{InstanceOptions, InstanceOptionsLegacy};
 use crate::platform::current_exe;
 use crate::portable::local::{InstanceInfo, lock_file, open_lock, runstate_dir};
@@ -289,8 +288,6 @@ fn set_inheritable(file: &impl std::os::unix::io::AsRawFd) -> anyhow::Result<()>
 }
 
 pub fn start(options: &Start) -> anyhow::Result<()> {
-    let _lock = LockManager::lock_instance(&options.instance_opts.instance_allow_legacy()?)?;
-
     // Special case: instance name is allowed to be positional for start, because start
     // is used in systemd services and cannot be changed.
     // Maybe we should make "fixup" that updates those services?

--- a/src/portable/instance/destroy.rs
+++ b/src/portable/instance/destroy.rs
@@ -18,7 +18,7 @@ use crate::{credentials, question};
 
 pub fn run(options: &Command, opts: &Options) -> anyhow::Result<()> {
     let name = options.instance_opts.instance()?;
-    let lock = LockManager::lock_instance(&name)?;
+    let _lock = LockManager::lock_instance(&name)?;
 
     let name_str = name.to_string();
     with_projects(&name_str, options.force, print_warning, || {
@@ -31,7 +31,6 @@ pub fn run(options: &Command, opts: &Options) -> anyhow::Result<()> {
                 return Err(ExitCode::new(exit_codes::NOT_CONFIRMED).into());
             }
         }
-        lock.lock_will_be_removed();
         match do_destroy(options, opts, &name) {
             Ok(()) => Ok(()),
             Err(e) if e.is::<InstanceNotFound>() => {

--- a/src/portable/instance/destroy.rs
+++ b/src/portable/instance/destroy.rs
@@ -6,6 +6,7 @@ use gel_tokio::InstanceName;
 
 use crate::branding::{BRANDING_CLI_CMD, BRANDING_CLOUD};
 use crate::commands::ExitCode;
+use crate::locking::LockManager;
 use crate::options::{CloudOptions, InstanceOptionsLegacy, Options};
 use crate::portable::exit_codes;
 use crate::portable::instance::control;
@@ -17,6 +18,7 @@ use crate::{credentials, question};
 
 pub fn run(options: &Command, opts: &Options) -> anyhow::Result<()> {
     let name = options.instance_opts.instance()?;
+    let _lock = LockManager::lock_instance(&name)?;
     let name_str = name.to_string();
     with_projects(&name_str, options.force, print_warning, || {
         if !options.force && !options.non_interactive {

--- a/src/portable/instance/destroy.rs
+++ b/src/portable/instance/destroy.rs
@@ -18,7 +18,8 @@ use crate::{credentials, question};
 
 pub fn run(options: &Command, opts: &Options) -> anyhow::Result<()> {
     let name = options.instance_opts.instance()?;
-    let _lock = LockManager::lock_instance(&name)?;
+    let lock = LockManager::lock_instance(&name)?;
+
     let name_str = name.to_string();
     with_projects(&name_str, options.force, print_warning, || {
         if !options.force && !options.non_interactive {
@@ -30,6 +31,7 @@ pub fn run(options: &Command, opts: &Options) -> anyhow::Result<()> {
                 return Err(ExitCode::new(exit_codes::NOT_CONFIRMED).into());
             }
         }
+        lock.lock_will_be_removed();
         match do_destroy(options, opts, &name) {
             Ok(()) => Ok(()),
             Err(e) if e.is::<InstanceNotFound>() => {

--- a/src/portable/instance/destroy.rs
+++ b/src/portable/instance/destroy.rs
@@ -119,7 +119,8 @@ fn destroy_local(name: &str) -> anyhow::Result<bool> {
         }
     }
     if paths.runstate_dir.exists() {
-        found = true;
+        // Don't set 'found' if the runstate exists since we might have a lock
+        // only
         log::info!("Removing runstate directory {:?}", paths.runstate_dir);
         fs::remove_dir_all(&paths.runstate_dir)?;
     }

--- a/src/portable/instance/revert.rs
+++ b/src/portable/instance/revert.rs
@@ -6,6 +6,7 @@ use gel_tokio::InstanceName;
 
 use crate::branding::{BRANDING, BRANDING_CLOUD};
 use crate::commands::ExitCode;
+use crate::locking::LockManager;
 use crate::options::InstanceOptionsLegacy;
 use crate::platform::tmp_file_path;
 use crate::portable::exit_codes;
@@ -23,6 +24,7 @@ pub fn run(options: &Command) -> anyhow::Result<()> {
     use BackupStatus::*;
 
     let instance = options.instance_opts.instance()?;
+    let _lock = LockManager::lock_instance(&instance)?;
 
     let name = match &instance {
         InstanceName::Local(name) => {

--- a/src/portable/instance/unlink.rs
+++ b/src/portable/instance/unlink.rs
@@ -5,6 +5,7 @@ use gel_tokio::InstanceName;
 use crate::branding::{BRANDING_CLI_CMD, BRANDING_CLOUD};
 use crate::credentials;
 use crate::hint::HintExt;
+use crate::locking::LockManager;
 use crate::options::InstanceOptionsLegacy;
 use crate::portable::instance::destroy::with_projects;
 use crate::portable::local::InstanceInfo;
@@ -12,6 +13,7 @@ use crate::portable::project;
 
 pub fn run(cmd: &Command) -> anyhow::Result<()> {
     let instance = cmd.instance_opts.instance()?;
+    let _lock = LockManager::lock_instance(&instance)?;
     let name = match &instance {
         InstanceName::Local(name) => name.clone(),
         inst_name => {

--- a/src/portable/instance/upgrade.rs
+++ b/src/portable/instance/upgrade.rs
@@ -14,6 +14,7 @@ use gel_tokio::{CloudName, InstanceName};
 use crate::branding::{BRANDING, BRANDING_CLI_CMD, BRANDING_CLOUD, QUERY_TAG};
 use crate::commands::{self, ExitCode};
 use crate::connect::{Connection, Connector};
+use crate::locking::LockManager;
 use crate::options::{CloudOptions, InstanceOptionsLegacy};
 use crate::portable::exit_codes;
 use crate::portable::instance::control;
@@ -29,6 +30,7 @@ use crate::question;
 use crate::{cloud, credentials};
 
 pub fn run(cmd: &Command, opts: &crate::options::Options) -> anyhow::Result<()> {
+    let _lock = LockManager::lock_instance(&cmd.instance_opts.instance()?)?;
     match cmd.instance_opts.instance()? {
         InstanceName::Local(name) => upgrade_local_cmd(cmd, &name, opts),
         InstanceName::Cloud(name) => upgrade_cloud_cmd(cmd, &name, opts),

--- a/src/portable/project/init.rs
+++ b/src/portable/project/init.rs
@@ -639,7 +639,7 @@ fn init_new(
             watch: Vec::new(),
         };
         project::manifest::write(&location.manifest, &manifest)?;
-        let ctx = project::Context { location, manifest };
+        let ctx = project::Context::new(location, manifest)?;
         if !schema_files {
             project::write_schema_default(&schema_dir_path, &ctx.manifest.instance.server_version)?;
         }
@@ -704,7 +704,7 @@ fn init_new(
                 watch: Vec::new(),
             };
             project::manifest::write(&location.manifest, &manifest)?;
-            let ctx = project::Context { location, manifest };
+            let ctx = project::Context::new(location, manifest)?;
             if !schema_files {
                 project::write_schema_default(&schema_dir_path, &Query::from_version(&version)?)?;
             }
@@ -771,7 +771,7 @@ fn init_new(
             };
 
             project::manifest::write(&location.manifest, &manifest)?;
-            let project = project::Context { location, manifest };
+            let project = project::Context::new(location, manifest)?;
             if !schema_files {
                 project::write_schema_default(
                     &schema_dir_path,

--- a/src/portable/project/mod.rs
+++ b/src/portable/project/mod.rs
@@ -325,7 +325,11 @@ pub struct Context {
 impl Context {
     pub fn new(location: Location, manifest: manifest::Manifest) -> Result<Self, anyhow::Error> {
         let project_lock = LockManager::lock_project(&location.root)?;
-        Ok(Self { location, manifest, project_lock: Some(project_lock) })
+        Ok(Self {
+            location,
+            manifest,
+            project_lock: Some(project_lock),
+        })
     }
 }
 
@@ -367,7 +371,11 @@ pub async fn load_ctx(override_dir: Option<&Path>) -> anyhow::Result<Option<Cont
 
     let manifest = manifest::read(&location.manifest)?;
     let lock = LockManager::lock_project(&location.root)?;
-    Ok(Some(Context { location, manifest, project_lock: Some(lock) }))
+    Ok(Some(Context {
+        location,
+        manifest,
+        project_lock: Some(lock),
+    }))
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -378,7 +386,11 @@ pub async fn load_ctx_at(location: Location) -> anyhow::Result<Context> {
 pub async fn load_ctx_at_async(location: Location) -> anyhow::Result<Context> {
     let manifest = manifest::read(&location.manifest)?;
     let lock = LockManager::lock_project_async(&location.root).await?;
-    Ok(Context { location, manifest, project_lock: Some(lock) })
+    Ok(Context {
+        location,
+        manifest,
+        project_lock: Some(lock),
+    })
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/src/portable/project/mod.rs
+++ b/src/portable/project/mod.rs
@@ -319,6 +319,7 @@ pub struct Context {
     pub location: Location,
     pub manifest: manifest::Manifest,
 
+    #[allow(unused)]
     project_lock: Option<ProjectLock>,
 }
 

--- a/src/portable/project/mod.rs
+++ b/src/portable/project/mod.rs
@@ -22,6 +22,7 @@ use crate::branding::QUERY_TAG;
 use crate::branding::{BRANDING_SCHEMA_FILE_EXT, MANIFEST_FILE_DISPLAY_NAME};
 use crate::cloud::client::CloudClient;
 use crate::connect::Connection;
+use crate::locking::InstanceLock;
 use crate::locking::LockManager;
 use crate::locking::ProjectLock;
 use crate::platform::{bytes_to_path, path_bytes};
@@ -321,16 +322,42 @@ pub struct Context {
 
     #[allow(unused)]
     project_lock: Option<ProjectLock>,
+
+    #[allow(unused)]
+    instance_lock: Option<InstanceLock>,
 }
 
 impl Context {
     pub fn new(location: Location, manifest: manifest::Manifest) -> Result<Self, anyhow::Error> {
         let project_lock = LockManager::lock_project(&location.root)?;
+        let stash_path = get_stash_path(&location.root)?;
+        let mut instance_lock = None;
+        if stash_path.exists() {
+            let instance_name = instance_name(&stash_path)?;
+            instance_lock = Some(LockManager::lock_maybe_read_instance(
+                &instance_name,
+                false,
+            )?);
+        }
+
         Ok(Self {
             location,
             manifest,
             project_lock: Some(project_lock),
+            instance_lock,
         })
+    }
+
+    pub fn downgrade_instance_lock(&self) -> anyhow::Result<()> {
+        if let Some(lock) = &self.instance_lock {
+            Ok(lock.downgrade()?)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn drop_project_lock(&mut self) {
+        self.project_lock = None;
     }
 }
 
@@ -365,17 +392,29 @@ pub fn find_project(override_dir: Option<&Path>) -> anyhow::Result<Option<Locati
     }))
 }
 
-pub async fn load_ctx(override_dir: Option<&Path>) -> anyhow::Result<Option<Context>> {
+pub async fn load_ctx(
+    override_dir: Option<&Path>,
+    read_only: bool,
+) -> anyhow::Result<Option<Context>> {
     let Some(location) = find_project_async(override_dir).await? else {
         return Ok(None);
     };
 
     let manifest = manifest::read(&location.manifest)?;
-    let lock = LockManager::lock_project(&location.root)?;
+    let stash_path = get_stash_path(&location.root)?;
+    let mut instance_lock = None;
+    if stash_path.exists() {
+        let instance_name = instance_name(&stash_path)?;
+        instance_lock =
+            Some(LockManager::lock_maybe_read_instance_async(&instance_name, read_only).await?);
+    }
+
+    let lock = LockManager::lock_maybe_read_project_async(&location.root, read_only).await?;
     Ok(Some(Context {
         location,
         manifest,
         project_lock: Some(lock),
+        instance_lock,
     }))
 }
 
@@ -387,10 +426,18 @@ pub async fn load_ctx_at(location: Location) -> anyhow::Result<Context> {
 pub async fn load_ctx_at_async(location: Location) -> anyhow::Result<Context> {
     let manifest = manifest::read(&location.manifest)?;
     let lock = LockManager::lock_project_async(&location.root).await?;
+    let stash_path = get_stash_path(&location.root)?;
+    let mut instance_lock = None;
+    if stash_path.exists() {
+        let instance_name = instance_name(&stash_path)?;
+        instance_lock =
+            Some(LockManager::lock_maybe_read_instance_async(&instance_name, false).await?);
+    }
     Ok(Context {
         location,
         manifest,
         project_lock: Some(lock),
+        instance_lock,
     })
 }
 
@@ -400,7 +447,7 @@ pub async fn ensure_ctx(override_dir: Option<&Path>) -> anyhow::Result<Context> 
 }
 
 pub async fn ensure_ctx_async(override_dir: Option<&Path>) -> anyhow::Result<Context> {
-    let Some(ctx) = load_ctx(override_dir).await? else {
+    let Some(ctx) = load_ctx(override_dir, false).await? else {
         return Err(anyhow::anyhow!(
             "`{MANIFEST_FILE_DISPLAY_NAME}` not found, unable to perform this action without an initialized project."
         ));

--- a/src/watch/scripts.rs
+++ b/src/watch/scripts.rs
@@ -48,6 +48,7 @@ pub async fn run_script(
         process::Native::new("", marker, "/bin/sh")
             .arg("-c")
             .arg(script)
+            .env("_GEL_IN_HOOK", "1")
             .current_dir(current_dir)
             .run_for_status()
             .await?
@@ -55,6 +56,7 @@ pub async fn run_script(
         process::Native::new("", marker, "cmd.exe")
             .arg("/c")
             .arg(script)
+            .env("_GEL_IN_HOOK", "1")
             .current_dir(current_dir)
             .run_for_status()
             .await?

--- a/tests/func/main.rs
+++ b/tests/func/main.rs
@@ -141,13 +141,6 @@ impl ServerGuard {
         spawn_command(cmd, Some(10000)).expect("start interactive")
     }
 
-    pub fn database_cmd(&self, database_name: &str) -> Command {
-        let mut cmd = self.admin_cmd();
-        cmd.arg("--tls-ca-file").arg(&self.0.info.tls_cert_file);
-        cmd.arg("--database").arg(database_name);
-        cmd
-    }
-
     pub fn ensure_instance_linked(&self) -> &'static str {
         const INSTANCE_NAME: &str = "_test_inst";
         edgedb_cli_cmd()

--- a/tests/scripts/link/script.cli
+++ b/tests/scripts/link/script.cli
@@ -183,7 +183,8 @@ $ gel instance destroy --instance=project1 --non-interactive
 %EXIT 8
 *
 ! gel error: Could not find Gel instance 'project1'
-optional {
+# Handle WSL bug where we duplicate this message
+if TARGET_OS == "windows" {
     *
     ! gel error: Could not find Gel instance 'project1'
 }

--- a/tests/scripts/project/watch.cli
+++ b/tests/scripts/project/watch.cli
@@ -86,10 +86,10 @@ $ gel query "select schema::Migration {*} filter .generated_by =
           schema::MigrationGeneratedBy.DevMode;"
 *
 
-$ echo "" >> dbschema/default.gel
+$ gel migrate --dev-mode
 *
 
-$ sleep 5
+$ sleep 1
 
 $ gel query "select schema::Migration {*} filter .generated_by =
           schema::MigrationGeneratedBy.DevMode;"

--- a/tests/scripts/project/watch.cli
+++ b/tests/scripts/project/watch.cli
@@ -1,0 +1,96 @@
+#!/usr/bin/env clitest --v0
+
+$ gel instance destroy -I watch_test --force
+%EXIT any
+*
+
+$ mktemp -d
+%SET WORK_DIR
+*
+
+defer {
+    $ rm -rf $WORK_DIR
+}
+
+$ mkdir $WORK_DIR/watch_test && echo "$WORK_DIR/watch_test"
+%SET PWD
+*
+
+$ gel project init --instance=watch_test --non-interactive
+*
+
+$ find .
+*
+
+background {
+   $ gel watch --migrate --verbose
+   %EXIT any
+   *
+}
+
+# Give it a second to start up
+$ sleep 1
+
+# Project is locked, so we can't switch to another branch
+$ gel branch switch --create --empty other
+%EXIT 1
+*
+! gel error: Could not acquire lock %{GREEDYDATA}
+
+$ gel query "select schema::Migration {*} filter .generated_by =
+          schema::MigrationGeneratedBy.DevMode;"
+*
+
+$ echo "module test {
+    type User {
+        name: str;
+    }
+}" > dbschema/default.gel
+*
+
+$ sleep 1
+
+$ gel query "select schema::Migration {*} filter .generated_by =
+          schema::MigrationGeneratedBy.DevMode;"
+*
+
+$ echo "module test {
+    type User {
+        name: str;
+    }
+    type User2 {
+        name: str;
+    }
+}" > dbschema/default.gel
+*
+
+$ sleep 1
+
+$ gel query "select schema::Migration {*} filter .generated_by =
+          schema::MigrationGeneratedBy.DevMode;"
+*
+
+$ gel migration create --non-interactive
+*
+
+$ find dbschema/
+*
+
+$ cat dbschema/migrations/*
+*
+
+$ sleep 1
+*
+
+$ gel query "select schema::Migration {*} filter .generated_by =
+          schema::MigrationGeneratedBy.DevMode;"
+*
+
+$ echo "" >> dbschema/default.gel
+*
+
+$ sleep 5
+
+$ gel query "select schema::Migration {*} filter .generated_by =
+          schema::MigrationGeneratedBy.DevMode;"
+*


### PR DESCRIPTION
We add a set of locks on instances and projects that control exclusive or shared access. This allows us to prevent failures when `gel watch` is running.

Most commands take an exclusive lock, but a few use a shared lock which allows them to run under gel project hooks. I might have missed some commands but it's easy enough to mark them as taking read-locks.

To simplify the implementation, we add locks into higher-level contexts in the CLI rather than individual commands where possible.
