### PR TITLE
Fix watch shutdown on interrupt

### DIFF
--- a/src/watch/fs_watcher.rs
+++ b/src/watch/fs_watcher.rs
@@ -33,7 +33,8 @@ impl FsWatcher {
         {
             let abort_tx = abort_tx.clone();
             abort_tasks.push(tokio::spawn(async move {
-                _ = tokio::signal::ctrl_c().await;
+                let ctrl_c = crate::interrupt::Interrupt::ctrl_c();
+                _ = ctrl_c.wait().await;
                 _ = abort_tx.send(());
             }));
         }
@@ -163,6 +164,7 @@ impl notify::EventHandler for WatchHandler {
     }
 }
 
+#[derive(Debug)]
 pub enum Event {
     /// Files have changed
     Changed(HashSet<PathBuf>),


### PR DESCRIPTION
We have code that handles interrupts, so that the CLI is shutdown
immediately if SIGINT is received. This is useful for aborting a slow
query or `gel instance list`.

This code is supressed when we are in the repl, where ctrl-c has a
different function.

This PR makes it so this is also the case for when we are in `watch`,
because we need to do cleanup after we stop watching, because we set
`force_database_error`. This was previously not done, because we used
Tokio's signal handling instead of our own.

From git log it looks like my mistake, from the series of PRs that
implemented watch scripts.
