### PR TITLE
Add watch test and fix dump test on Windows

### DIFF
--- a/.github/workflows/new-tests.yml
+++ b/.github/workflows/new-tests.yml
@@ -141,8 +141,9 @@ jobs:
         run: |
           gel instance create -I _placeholder_
           gel instance destroy --non-interactive -I _placeholder_
-          wsl cp artifacts/debug-gel-cli-Linux/gel /usr/bin/gel.new
-          wsl --exec sh -c 'cp /usr/bin/gel.new /usr/bin/gel && cp /usr/bin/gel.new /usr/bin/edgedb'
+          wsl cp artifacts/debug-gel-cli-Linux/gel /usr/bin/edgedb
+          wsl cp artifacts/debug-gel-cli-Linux/gel /usr/bin/gel
+          echo "_GEL_WSL_SKIP_UPDATE=true" >> $GITHUB_ENV
 
       - name: Set executable permissions
         if: runner.os != 'Windows'
@@ -155,25 +156,25 @@ jobs:
 
       - name: Run backup/backup.cli test
         run: |
-          _GEL_WSL_SKIP_UPDATE=true TERM=xterm-256color clitest tests/scripts/backup/backup.cli
+          TERM=xterm-256color clitest tests/scripts/backup/backup.cli
         shell: bash
 
       - name: Run dump/dump.cli test
         run: |
-          _GEL_WSL_SKIP_UPDATE=true TERM=xterm-256color clitest tests/scripts/dump/dump.cli
+          TERM=xterm-256color clitest tests/scripts/dump/dump.cli
         shell: bash
 
       - name: Run link/script.cli test
         run: |
-          _GEL_WSL_SKIP_UPDATE=true TERM=xterm-256color clitest tests/scripts/link/script.cli
+          TERM=xterm-256color clitest tests/scripts/link/script.cli
         shell: bash
 
       - name: Run project/hooks.cli test
         run: |
-          _GEL_WSL_SKIP_UPDATE=true TERM=xterm-256color clitest tests/scripts/project/hooks.cli
+          TERM=xterm-256color clitest tests/scripts/project/hooks.cli
         shell: bash
 
       - name: Run project/watch.cli test
         run: |
-          _GEL_WSL_SKIP_UPDATE=true TERM=xterm-256color clitest tests/scripts/project/watch.cli
+          TERM=xterm-256color clitest tests/scripts/project/watch.cli
         shell: bash

--- a/.github/workflows/new-tests.yml
+++ b/.github/workflows/new-tests.yml
@@ -172,7 +172,9 @@ jobs:
           TERM=xterm-256color clitest tests/scripts/project/hooks.cli
         shell: bash
 
+      # WSL networking issues...
       - name: Run project/watch.cli test
+        if: runner.os != 'Windows'
         run: |
           TERM=xterm-256color clitest tests/scripts/project/watch.cli
         shell: bash

--- a/.github/workflows/new-tests.yml
+++ b/.github/workflows/new-tests.yml
@@ -140,10 +140,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          gel instance create -I _placeholder_
-          gel instance destroy --non-interactive -I _placeholder_
-          wsl cp artifacts/debug-gel-cli-Linux/gel /usr/bin/edgedb
-          wsl cp artifacts/debug-gel-cli-Linux/gel /usr/bin/gel
+          _GEL_WSL_LINUX_BINARY=artifacts/debug-gel-cli-Linux/gel gel cli __initwsl
           echo "_GEL_WSL_SKIP_UPDATE=true" >> $GITHUB_ENV
 
       - name: Set executable permissions

--- a/.github/workflows/new-tests.yml
+++ b/.github/workflows/new-tests.yml
@@ -148,9 +148,10 @@ jobs:
         run: |
           chmod +x ${{ env.CARGO_HOME }}/bin/*
 
-      - name: Print version
+      - name: Print versions
         run: |
-          gel --version
+          echo "gel: $(gel --version)"
+          echo "clitest: $(clitest --version)"
 
       - name: Run backup/backup.cli test
         run: |

--- a/.github/workflows/new-tests.yml
+++ b/.github/workflows/new-tests.yml
@@ -140,7 +140,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          _GEL_WSL_LINUX_BINARY=artifacts/debug-gel-cli-Linux/gel gel cli __initwsl
+          _GEL_WSL_LINUX_BINARY=artifacts/debug-gel-cli-Linux/gel gel cli init-wsl
           echo "_GEL_WSL_SKIP_UPDATE=true" >> $GITHUB_ENV
 
       - name: Set executable permissions

--- a/.github/workflows/new-tests.yml
+++ b/.github/workflows/new-tests.yml
@@ -172,14 +172,14 @@ jobs:
           TERM=xterm-256color clitest tests/scripts/project/hooks.cli
         shell: bash
 
-      # WSL networking issues...
-      - name: Run project/watch.cli test
-        if: runner.os != 'Windows'
-        run: |
-          TERM=xterm-256color clitest tests/scripts/project/watch.cli
-        shell: bash
-
       - name: Run query/txn.cli test
         run: |
           TERM=xterm-256color clitest tests/scripts/query/txn.cli
+        shell: bash
+
+      # WSL networking issues...
+      - name: Run project/watch.cli test
+        # if: runner.os != 'Windows'
+        run: |
+          TERM=xterm-256color clitest tests/scripts/project/watch.cli
         shell: bash

--- a/.github/workflows/new-tests.yml
+++ b/.github/workflows/new-tests.yml
@@ -178,3 +178,8 @@ jobs:
         run: |
           TERM=xterm-256color clitest tests/scripts/project/watch.cli
         shell: bash
+
+      - name: Run query/txn.cli test
+        run: |
+          TERM=xterm-256color clitest tests/scripts/query/txn.cli
+        shell: bash

--- a/.github/workflows/new-tests.yml
+++ b/.github/workflows/new-tests.yml
@@ -172,3 +172,8 @@ jobs:
         run: |
           _GEL_WSL_SKIP_UPDATE=true TERM=xterm-256color clitest tests/scripts/project/hooks.cli
         shell: bash
+
+      - name: Run project/watch.cli test
+        run: |
+          _GEL_WSL_SKIP_UPDATE=true TERM=xterm-256color clitest tests/scripts/project/watch.cli
+        shell: bash

--- a/.github/workflows/new-tests.yml
+++ b/.github/workflows/new-tests.yml
@@ -138,6 +138,7 @@ jobs:
 
       - name: Setup WSL
         if: runner.os == 'Windows'
+        shell: bash
         run: |
           gel instance create -I _placeholder_
           gel instance destroy --non-interactive -I _placeholder_

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -158,8 +158,8 @@ jobs:
         test: [portable_smoke, shared_client_tests]
       fail-fast: false
     env:
-      _EDGEDB_WSL_DISTRO: Debian
-      _EDGEDB_WSL_LINUX_BINARY: ./linux-binary/gel
+      _GEL_WSL_DISTRO: Debian
+      _GEL_WSL_LINUX_BINARY: ./linux-binary/gel
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.9",
  "serde",
 ]
 
@@ -667,6 +667,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-str"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e991226a70654b49d34de5ed064885f0bef0348a8e70018b8ff1ac80aa984a2"
+
+[[package]]
 name = "const_format"
 version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +764,12 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crokey"
@@ -1640,6 +1652,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gel-db-protocol"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e58b0e58b8ace253d135f20ef4d1aa7bbd3ccb8244204f3a0c1a84465cf091d6"
+dependencies = [
+ "const-str",
+ "derive_more",
+ "paste",
+ "thiserror 2.0.12",
+ "uuid",
+]
+
+[[package]]
 name = "gel-derive"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "gel-errors"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1266263c0bd743a624a6a28b752638afcb3c8c3bbf0291756d3989750050aa27"
+checksum = "b0df99688f2b3c2ebdec22be88fe572a9c9b6ce5244bb819a47617d8fd63d51f"
 dependencies = [
  "bytes",
 ]
@@ -1721,14 +1746,15 @@ dependencies = [
 
 [[package]]
 name = "gel-protocol"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa66acf022c63a1146131001c45f9e55127a9b9857c334b87b1d06a5baf9dd8b"
+checksum = "898c6279201bf032d9b59cb5a81770ed93c4beceb84f7e6ce4a213459f37fa39"
 dependencies = [
  "bigdecimal",
  "bitflags 2.9.0",
  "bytes",
  "chrono",
+ "gel-db-protocol",
  "gel-errors",
  "num-bigint",
  "num-traits",
@@ -1740,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "gel-stream"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e909aa3f3404f0a9a8ea2d7c2716071d1737871dcedd501e8c51704ddc7b39"
+checksum = "cb477575c47313ddbcf9da3cd13829ba81652bad8a20e92b294dcef27b87d247"
 dependencies = [
  "derive_more",
  "futures",
@@ -1761,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "gel-tokio"
-version = "0.10.11"
+version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0e985ac7a4450ec2d256411c5c672ae1391d06bd075253dad1b63b6b95ad19b"
+checksum = "2c545753c847a197cead8c666f20d4fe2cee5a8aa5646349568184617db5ff7f"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1789,6 +1815,20 @@ dependencies = [
  "sha1",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
 ]
 
 [[package]]
@@ -1898,8 +1938,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2014,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.24.4"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2028,8 +2068,9 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.8.5",
- "thiserror 1.0.69",
+ "rand 0.9.0",
+ "ring",
+ "thiserror 2.0.12",
  "tinyvec",
  "tokio",
  "tracing",
@@ -2038,21 +2079,21 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.4"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
  "hickory-proto",
  "ipconfig",
- "lru-cache",
+ "moka",
  "once_cell",
  "parking_lot 0.12.3",
- "rand 0.8.5",
+ "rand 0.9.0",
  "resolv-conf",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -2704,12 +2745,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2750,12 +2785,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
-name = "lru-cache"
-version = "0.1.2"
+name = "loom"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
 dependencies = [
- "linked-hash-map",
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -2835,6 +2883,25 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "loom",
+ "parking_lot 0.12.3",
+ "portable-atomic",
+ "rustc_version",
+ "smallvec",
+ "tagptr",
+ "thiserror 1.0.69",
+ "uuid",
 ]
 
 [[package]]
@@ -2936,6 +3003,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3028,6 +3105,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "open"
@@ -3108,6 +3189,12 @@ checksum = "82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -3636,8 +3723,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -3648,8 +3744,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -4021,9 +4123,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-tokio-stream"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa7dc7c991d9164e55bbf1558029eb5b84d32cc4d61a7df5b8641b2deedc4b3"
+checksum = "d522eeacb38c78777fb1225a25cec4b165eddeb03378c2b39f9683e0cc0a432b"
 dependencies = [
  "futures",
  "rustls 0.23.26",
@@ -4276,6 +4378,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared-client-tests"
 version = "0.1.0"
 dependencies = [
@@ -4495,6 +4606,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4691,6 +4808,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -4914,6 +5041,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -5046,6 +5203,12 @@ dependencies = [
  "rand 0.9.0",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -5286,9 +5449,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5354,10 +5517,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings 0.4.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -5366,7 +5606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
- "windows-strings",
+ "windows-strings 0.3.1",
  "windows-targets 0.53.0",
 ]
 
@@ -5384,6 +5624,15 @@ name = "windows-strings"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1766,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "gel-stream"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb477575c47313ddbcf9da3cd13829ba81652bad8a20e92b294dcef27b87d247"
+checksum = "0a3d58f04723506dc16207b0973f885d82af8e94ff6b7f950818179e14cf851e"
 dependencies = [
  "derive_more",
  "futures",
@@ -1787,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "gel-tokio"
-version = "0.10.14"
+version = "0.10.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c545753c847a197cead8c666f20d4fe2cee5a8aa5646349568184617db5ff7f"
+checksum = "cf8b68343538f8c93fff5cc1353b9bdd151d3bf782a71e38683a3357e3844a94"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ gel-protocol = { version = "0.8", features = ["all-types"] }
 gel-derive = { version = "0.7" }
 gel-errors = { version = "0.5" }
 gel-auth = { version = "0.1" }
-gel-tokio = { version = "0.10", features=["admin_socket", "unstable"] }
+gel-tokio = { version = "0.10.14", features=["admin_socket", "unstable"] }
 gel-dsn = { version = "0.2" }
 gel-jwt = { version = "0.1", features = ["gel"] }
 

--- a/src/branch/mod.rs
+++ b/src/branch/mod.rs
@@ -10,6 +10,8 @@ pub mod rename;
 pub mod switch;
 pub mod wipe;
 
+use futures_util::FutureExt;
+
 use crate::branding::BRANDING;
 use crate::commands::Options;
 use crate::connect::{Connection, Connector};
@@ -32,7 +34,9 @@ pub async fn run(
 
     // commands that don't need connection
     match &cmd {
-        Subcommand::Switch(switch) => return switch::run(switch, &context, &mut connector).await,
+        Subcommand::Switch(switch) => {
+            return switch::run(switch, &context, &mut connector).boxed().await;
+        }
         Subcommand::Wipe(wipe) => {
             wipe::main(wipe, &context, &mut connector).await?;
             return Ok(CommandResult::default());

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -105,11 +105,11 @@ define_env! {
     _wsl_skip_update: bool,
 
     /// WSL distro name
-    #[env(_GEL_WSL_DISTRO, _EDGEDB_WSL_DISTRO)]
+    #[env(_GEL_WSL_DISTRO)]
     _wsl_distro: String,
 
     /// Path to WSL Linux binary
-    #[env(_GEL_WSL_LINUX_BINARY, _EDGEDB_WSL_LINUX_BINARY)]
+    #[env(_GEL_WSL_LINUX_BINARY)]
     _wsl_linux_binary: PathBuf,
 
     /// Flag indicating Windows wrapper

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,5 @@
+use crate::portable;
+
 pub mod env;
 pub mod gen_completions;
 pub mod install;
@@ -22,6 +24,9 @@ pub enum Subcommand {
     /// Install the [`BRANDING_CLI_CMD`] command-line tool
     #[command(hide = true)]
     Install(install::Command),
+    /// Force WSL initialization
+    #[command(hide = true)]
+    __InitWsl(portable::windows::InitWslCommand),
 }
 
 pub fn run(cmd: &Command, opts: &crate::options::Options) -> anyhow::Result<()> {
@@ -30,5 +35,6 @@ pub fn run(cmd: &Command, opts: &crate::options::Options) -> anyhow::Result<()> 
     match &cmd.subcommand {
         Upgrade(s) => upgrade::run(s),
         Install(s) => install::run(s, Some(opts)),
+        __InitWsl(s) => portable::windows::init_wsl(s, opts),
     }
 }

--- a/src/portable/instance/destroy.rs
+++ b/src/portable/instance/destroy.rs
@@ -171,7 +171,10 @@ fn do_destroy(options: &Command, opts: &Options, instance: &InstanceName) -> any
                 found = true;
                 credentials::delete(instance)?;
             } else {
-                log::warn!("Credentials unexpectedly missing for {:#}", instance);
+                // Only warn if we actually found any instance data.
+                if found {
+                    log::warn!("Credentials unexpectedly missing for {:#}", instance);
+                }
             }
             if !found {
                 msg!("{} Could not find {:#}", print::err_marker(), instance);

--- a/src/portable/instance/destroy.rs
+++ b/src/portable/instance/destroy.rs
@@ -176,8 +176,10 @@ fn do_destroy(options: &Command, opts: &Options, instance: &InstanceName) -> any
                     log::warn!("Credentials unexpectedly missing for {:#}", instance);
                 }
             }
-            if !found && !windows::is_wrapped() {
-                msg!("{} Could not find {:#}", print::err_marker(), instance);
+            if !found {
+                if !windows::is_wrapped() {
+                    msg!("{} Could not find {:#}", print::err_marker(), instance);
+                }
                 return Err(ExitCode::new(exit_codes::INSTANCE_NOT_FOUND).into());
             }
             Ok(())

--- a/src/portable/instance/destroy.rs
+++ b/src/portable/instance/destroy.rs
@@ -176,7 +176,7 @@ fn do_destroy(options: &Command, opts: &Options, instance: &InstanceName) -> any
                     log::warn!("Credentials unexpectedly missing for {:#}", instance);
                 }
             }
-            if !found {
+            if !found && !windows::is_wrapped() {
                 msg!("{} Could not find {:#}", print::err_marker(), instance);
                 return Err(ExitCode::new(exit_codes::INSTANCE_NOT_FOUND).into());
             }

--- a/src/portable/linux.rs
+++ b/src/portable/linux.rs
@@ -7,6 +7,7 @@ use fn_error_context::context;
 use gel_tokio::InstanceName;
 
 use crate::branding::BRANDING_CLOUD;
+use crate::cli::env::Env;
 use crate::commands::ExitCode;
 use crate::platform::{current_exe, detect_ipv6, home_dir};
 use crate::portable::instance::control;
@@ -15,6 +16,8 @@ use crate::portable::instance::status;
 use crate::portable::local::{InstanceInfo, log_file, runstate_dir};
 use crate::print;
 use crate::process;
+
+use super::windows;
 
 pub fn unit_dir() -> anyhow::Result<PathBuf> {
     Ok(home_dir()?.join(".config/systemd/user"))
@@ -238,6 +241,10 @@ pub fn server_cmd(
 }
 
 pub fn detect_systemd(instance: &str) -> bool {
+    // Never use systemd on gel-managed WSL instances
+    if windows::is_wrapped() {
+        return false;
+    }
     _detect_systemd(instance).is_some()
 }
 

--- a/src/portable/linux.rs
+++ b/src/portable/linux.rs
@@ -236,6 +236,7 @@ pub fn server_cmd(
             pro.arg("--auto-shutdown-after=600");
         }
     }
+    pro.no_proxy();
     Ok(pro)
 }
 

--- a/src/portable/linux.rs
+++ b/src/portable/linux.rs
@@ -241,14 +241,14 @@ pub fn server_cmd(
 }
 
 pub fn detect_systemd(instance: &str) -> bool {
-    // Never use systemd on gel-managed WSL instances
-    if windows::is_wrapped() {
-        return false;
-    }
     _detect_systemd(instance).is_some()
 }
 
 fn preliminary_detect() -> Option<PathBuf> {
+    // Never use systemd on gel-managed WSL instances
+    if windows::is_wrapped() {
+        return None;
+    }
     env::var_os("XDG_RUNTIME_DIR").or_else(|| env::var_os("DBUS_SESSION_BUS_ADDRESS"))?;
     if let Ok(path) = which::which("systemctl") {
         Some(path)

--- a/src/portable/linux.rs
+++ b/src/portable/linux.rs
@@ -7,7 +7,6 @@ use fn_error_context::context;
 use gel_tokio::InstanceName;
 
 use crate::branding::BRANDING_CLOUD;
-use crate::cli::env::Env;
 use crate::commands::ExitCode;
 use crate::platform::{current_exe, detect_ipv6, home_dir};
 use crate::portable::instance::control;

--- a/src/portable/macos.rs
+++ b/src/portable/macos.rs
@@ -334,6 +334,7 @@ pub fn server_cmd(
             pro.arg("--auto-shutdown-after=600");
         }
     }
+    pro.no_proxy();
     Ok(pro)
 }
 

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -736,6 +736,7 @@ pub fn server_cmd(instance: &str, _is_shutdown_supported: bool) -> anyhow::Resul
         cmd.arg("instance").arg("stop").arg("-I").arg(&instance);
         cmd
     });
+    pro.no_proxy();
     Ok(pro)
 }
 

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -63,6 +63,15 @@ static IS_IN_WSL: LazyLock<bool> = LazyLock::new(|| {
 
 const USR_BIN_EXE: &str = const_format::concatcp!("/usr/bin/", BRANDING_CLI_CMD);
 
+#[derive(clap::Args, Clone, Debug)]
+pub struct InitWslCommand {
+}
+
+pub fn init_wsl(_cmd: &InitWslCommand, _opts: &crate::Options) -> anyhow::Result<()> {
+    ensure_wsl()?;
+    Ok(())
+}
+
 #[derive(Debug, thiserror::Error)]
 #[error("WSL distribution is not installed")]
 pub struct NoDistribution;

--- a/src/portable/windows.rs
+++ b/src/portable/windows.rs
@@ -64,8 +64,7 @@ static IS_IN_WSL: LazyLock<bool> = LazyLock::new(|| {
 const USR_BIN_EXE: &str = const_format::concatcp!("/usr/bin/", BRANDING_CLI_CMD);
 
 #[derive(clap::Args, Clone, Debug)]
-pub struct InitWslCommand {
-}
+pub struct InitWslCommand {}
 
 pub fn init_wsl(_cmd: &InitWslCommand, _opts: &crate::Options) -> anyhow::Result<()> {
     ensure_wsl()?;

--- a/tests/scripts/dump/dump.cli
+++ b/tests/scripts/dump/dump.cli
@@ -77,6 +77,11 @@ $ gel instance create -I dump_restore2
 $ echo "password" | gel -I dump_restore2 instance reset-password --password-from-stdin
 ! Password was successfully changed and saved.
 
+background {
+    $ gel -I dump_restore2 instance logs --tail 10 --follow
+    *
+}
+
 $ gel -I dump_restore2 restore --all $WORK_DIR/dump_all
 repeat {
     !

--- a/tests/scripts/dump/dump.cli
+++ b/tests/scripts/dump/dump.cli
@@ -83,6 +83,12 @@ repeat {
     ? Restoring database from file %{GREEDYDATA}
     ! Restore completed
 }
+# This started happening on Windows
+if TARGET_OS == "windows" {
+    optional {
+        ! gel error: ClientConnectionError: peer closed connection without sending TLS close_notify
+    }
+}
 
 $ gel -I dump_restore2 --database dump_01 query "SELECT Hello.name"
 ! "world"

--- a/tests/scripts/dump/dump.cli
+++ b/tests/scripts/dump/dump.cli
@@ -80,6 +80,7 @@ $ echo "password" | gel -I dump_restore2 instance reset-password --password-from
 background {
     $ gel -I dump_restore2 instance logs --tail 10 --follow
     *
+    %EXIT any
 }
 
 $ gel -I dump_restore2 restore --all $WORK_DIR/dump_all

--- a/tests/scripts/dump/dump.cli
+++ b/tests/scripts/dump/dump.cli
@@ -89,12 +89,6 @@ repeat {
     ? Restoring database from file %{GREEDYDATA}
     ! Restore completed
 }
-# This started happening on Windows
-if TARGET_OS == "windows" {
-    optional {
-        ! gel error: ClientConnectionError: peer closed connection without sending TLS close_notify
-    }
-}
 
 $ gel -I dump_restore2 --database dump_01 query "SELECT Hello.name"
 ! "world"

--- a/tests/scripts/dump/dump.cli
+++ b/tests/scripts/dump/dump.cli
@@ -79,8 +79,8 @@ $ echo "password" | gel -I dump_restore2 instance reset-password --password-from
 
 background {
     $ gel -I dump_restore2 instance logs --tail 10 --follow
-    *
     %EXIT any
+    *
 }
 
 $ gel -I dump_restore2 restore --all $WORK_DIR/dump_all

--- a/tests/scripts/link/script.cli
+++ b/tests/scripts/link/script.cli
@@ -50,6 +50,9 @@ repeat {
 ? └%{DATA}┴%{DATA}┴%{DATA}┘
 
 $ gel instance create inst1
+ignore {
+    ! [edgedb] %{GREEDYDATA}
+}
 choice {
     sequence {
         ? Downloading package...

--- a/tests/scripts/link/script.cli
+++ b/tests/scripts/link/script.cli
@@ -178,11 +178,6 @@ $ gel instance destroy --instance=project1 --non-interactive
 %EXIT 8
 *
 ! gel error: Could not find Gel instance 'project1'
-# Handle WSL bug where we duplicate this message
-if TARGET_OS == "windows" {
-    *
-    ! gel error: Could not find Gel instance 'project1'
-}
 
 $ gel instance list
 *

--- a/tests/scripts/link/script.cli
+++ b/tests/scripts/link/script.cli
@@ -16,8 +16,8 @@ pattern VERSION (\d+\.\d+(?:\.\d+)?(?:-(?:alpha|beta|rc|dev)\.\d+)?\+(?:[a-f0-9]
 
 ignore {
     ? Newer version of gel tool exists %{VERSION} \(current %{VERSION}\). To upgrade run `gel cli upgrade`
-    ? WARNING %{GREEDYDATA} postgres: %{GREEDYDATA}
-    ? CRITICAL %{GREEDYDATA} postgres: %{GREEDYDATA}
+    ! [edgedb] WARNING %{GREEDYDATA} postgres: %{GREEDYDATA}
+    ! [edgedb] CRITICAL %{GREEDYDATA} postgres: %{GREEDYDATA}
 }
 
 $ gel instance destroy -I inst1 --force
@@ -50,9 +50,6 @@ repeat {
 ? └%{DATA}┴%{DATA}┴%{DATA}┘
 
 $ gel instance create inst1
-ignore {
-    ! [edgedb] %{GREEDYDATA}
-}
 choice {
     sequence {
         ? Downloading package...
@@ -129,7 +126,6 @@ optional {
 $ gel project upgrade --force --project-dir=$WORK_DIR/proj/project2
 ignore {
     ! [systemctl] %{GREEDYDATA}
-    ! [edgedb] %{GREEDYDATA}
 }
 choice {
     sequence {

--- a/tests/scripts/project/watch.cli
+++ b/tests/scripts/project/watch.cli
@@ -9,6 +9,11 @@ $ mktemp -d
 *
 
 defer {
+    $ cat /tmp/log
+    *
+}
+
+defer {
     $ rm -rf $WORK_DIR
 }
 
@@ -103,11 +108,6 @@ $ gel query "select schema::Migration {*} filter .generated_by =
 *
 
 $ sleep 1
-
-defer {
-    $ cat /tmp/log
-    *
-}
 
 # This seems to be racing with gel watch
 $ RUST_LOG=debug gel migrate --dev-mode 2> /tmp/log

--- a/tests/scripts/project/watch.cli
+++ b/tests/scripts/project/watch.cli
@@ -13,7 +13,7 @@ defer {
 }
 
 if TARGET_OS == "windows" {
-    $ mkdir $WORK_DIR/watch_test && cmd //c echo "%WORK_DIR%/watch_test"
+    $ mkdir $WORK_DIR/watch_test && cmd //c echo "%WORK_DIR%/watch_test" 2> /dev/null
     %SET PWD
     *
 }

--- a/tests/scripts/project/watch.cli
+++ b/tests/scripts/project/watch.cli
@@ -13,6 +13,8 @@ defer {
 }
 
 if TARGET_OS == "windows" {
+    # Because mktemp is MINGW and doesn't use real windows paths, we need to
+    # set PWD using the translated path.
     $ mkdir $WORK_DIR/watch_test && cmd //c echo "%WORK_DIR%/watch_test" 2> /dev/null
     %SET PWD
     *

--- a/tests/scripts/project/watch.cli
+++ b/tests/scripts/project/watch.cli
@@ -98,8 +98,12 @@ $ gel query "select schema::Migration {*} filter .generated_by =
 
 $ sleep 1
 
+defer {
+    $ gel instance logs -I watch_test
+}
+
 # This seems to be racing with gel watch
-$ RUST_LOG=debuggel migrate --dev-mode
+$ RUST_LOG=debug gel migrate --dev-mode
 *
 
 $ sleep 1

--- a/tests/scripts/project/watch.cli
+++ b/tests/scripts/project/watch.cli
@@ -12,9 +12,17 @@ defer {
     $ rm -rf $WORK_DIR
 }
 
-$ mkdir $WORK_DIR/watch_test && echo "$WORK_DIR/watch_test"
-%SET PWD
-*
+if TARGET_OS == "windows" {
+    $ mkdir $WORK_DIR/watch_test && cmd //c echo "%WORK_DIR%/watch_test"
+    %SET PWD
+    *
+}
+
+if TARGET_OS != "windows" {
+    $ mkdir $WORK_DIR/watch_test && echo "$WORK_DIR/watch_test"
+    %SET PWD
+    *
+}
 
 $ gel project init --instance=watch_test --non-interactive
 *

--- a/tests/scripts/project/watch.cli
+++ b/tests/scripts/project/watch.cli
@@ -99,7 +99,7 @@ $ gel query "select schema::Migration {*} filter .generated_by =
 $ sleep 1
 
 # This seems to be racing with gel watch
-$ gel migrate --dev-mode
+$ RUST_LOG=debuggel migrate --dev-mode
 *
 
 $ sleep 1

--- a/tests/scripts/project/watch.cli
+++ b/tests/scripts/project/watch.cli
@@ -104,8 +104,13 @@ $ gel query "select schema::Migration {*} filter .generated_by =
 
 $ sleep 1
 
+defer {
+    $ cat /tmp/log
+    *
+}
+
 # This seems to be racing with gel watch
-$ RUST_LOG=debug gel migrate --dev-mode
+$ RUST_LOG=debug gel migrate --dev-mode 2> /tmp/log
 *
 
 $ sleep 1

--- a/tests/scripts/project/watch.cli
+++ b/tests/scripts/project/watch.cli
@@ -96,6 +96,9 @@ $ gel query "select schema::Migration {*} filter .generated_by =
           schema::MigrationGeneratedBy.DevMode;"
 *
 
+$ sleep 1
+
+# This seems to be racing with gel watch
 $ gel migrate --dev-mode
 *
 

--- a/tests/scripts/project/watch.cli
+++ b/tests/scripts/project/watch.cli
@@ -110,7 +110,7 @@ $ gel query "select schema::Migration {*} filter .generated_by =
 $ sleep 1
 
 # This seems to be racing with gel watch
-$ RUST_LOG=debug gel migrate --dev-mode 2> /tmp/log
+$ gel migrate --dev-mode 2> /tmp/log
 *
 
 $ sleep 1

--- a/tests/scripts/project/watch.cli
+++ b/tests/scripts/project/watch.cli
@@ -38,6 +38,12 @@ background {
    *
 }
 
+background {
+    $ gel instance logs -I watch_test --follow --tail 10
+    %EXIT any
+    *
+}
+
 # Give it a second to start up
 $ sleep 1
 
@@ -97,10 +103,6 @@ $ gel query "select schema::Migration {*} filter .generated_by =
 *
 
 $ sleep 1
-
-defer {
-    $ gel instance logs -I watch_test
-}
 
 # This seems to be racing with gel watch
 $ RUST_LOG=debug gel migrate --dev-mode

--- a/tests/scripts/query/txn.cli
+++ b/tests/scripts/query/txn.cli
@@ -1,0 +1,26 @@
+#!/usr/bin/env clitest --v0
+
+ignore {
+    ! Newer version of gel tool exists %{GREEDYDATA}
+}
+
+$ gel instance destroy -I txn_test --force
+%EXIT any
+*
+
+$ gel instance create -I txn_test
+*
+
+background {
+    $ (echo "start transaction;"; echo "create type MyUser { create property name: str; };"; sleep 10; echo "commit";) | gel -I txn_test
+    ! OK: START TRANSACTION
+    ! OK: CREATE TYPE
+    ! OK: COMMIT TRANSACTION
+}
+
+$ sleep 1
+*
+
+$ gel -I txn_test query "create type MyUser { create property name: str; }"
+%EXIT 1
+! gel error: TransactionSerializationError: could not serialize access due to concurrent update

--- a/tests/scripts/query/txn.cli
+++ b/tests/scripts/query/txn.cli
@@ -2,6 +2,7 @@
 
 ignore {
     ! Newer version of gel tool exists %{GREEDYDATA}
+    ! Connecting to Gel instance %{GREEDYDATA}
 }
 
 $ gel instance destroy -I txn_test --force
@@ -24,3 +25,6 @@ $ sleep 1
 $ gel -I txn_test query "create type MyUser { create property name: str; }"
 %EXIT 1
 ! gel error: TransactionSerializationError: could not serialize access due to concurrent update
+
+$ sleep 1
+*

--- a/tests/scripts/query/txn.cli
+++ b/tests/scripts/query/txn.cli
@@ -14,17 +14,19 @@ $ gel instance create -I txn_test
 
 background {
     $ (echo "start transaction;"; echo "create type MyUser { create property name: str; };"; sleep 10; echo "commit";) | gel -I txn_test
+    %EXIT any
     ! OK: START TRANSACTION
     ! OK: CREATE TYPE
     ! OK: COMMIT TRANSACTION
 }
 
-$ sleep 1
+$ sleep 5
 *
 
 $ gel -I txn_test query "create type MyUser { create property name: str; }"
 %EXIT 1
 ! gel error: TransactionSerializationError: could not serialize access due to concurrent update
 
+# Allow the background transaction to complete
 $ sleep 1
 *


### PR DESCRIPTION
Adds a new watch CLI test that we can use to validate that watch functionality continues to work.  

As part of this, it was discovered that the Windows experience was pretty bad so a number of Windows fixes went into this as well.