### PR TITLE
Prevent git branch while `gel watch` runs

### DIFF
--- a/.github/workflows/new-tests.yml
+++ b/.github/workflows/new-tests.yml
@@ -178,9 +178,7 @@ jobs:
           TERM=xterm-256color clitest tests/scripts/query/txn.cli
         shell: bash
 
-      # WSL networking issues...
       - name: Run project/watch.cli test
-        # if: runner.os != 'Windows'
         run: |
           TERM=xterm-256color clitest tests/scripts/project/watch.cli
         shell: bash

--- a/gel-cli-instance/src/lib.rs
+++ b/gel-cli-instance/src/lib.rs
@@ -70,7 +70,7 @@ impl From<(Command, ProcessErrorType)> for ProcessError {
     }
 }
 
-struct Processes<P: ProcessRunner> {
+pub struct Processes<P: ProcessRunner> {
     runner: P,
 }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,0 +1,36 @@
+use std::process::Command;
+
+use gel_cli_instance::{ProcessError, ProcessErrorType, Processes, SystemProcessRunner};
+use log::warn;
+
+/// Get the current git branch.
+///
+/// Returns `None` if git is not installed. Returns `None` if the current branch
+/// is not available, ie: if we are not in a git repository or the current HEAD
+/// is detached.
+pub async fn git_current_branch() -> Option<String> {
+    let process_runner = SystemProcessRunner;
+
+    let mut cmd = Command::new("git");
+    cmd.args(["branch", "--show-current"]);
+    match Processes::new(process_runner)
+        .run_string(cmd)
+        .await
+        .map(|s| s.trim().to_string())
+    {
+        Ok(branch) if branch.is_empty() => None,
+        Ok(branch) => Some(branch),
+        Err(ProcessError {
+            kind: ProcessErrorType::Io(e),
+            ..
+        }) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(ProcessError {
+            kind: ProcessErrorType::CommandFailed(status, _),
+            ..
+        }) if status.code() == Some(128) => None,
+        Err(e) => {
+            warn!("Failed to get current git branch: {}", e);
+            None
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ mod credentials;
 mod docker;
 mod error_display;
 mod format;
+mod git;
 mod highlight;
 mod hint;
 mod hooks;

--- a/src/watch/migrate.rs
+++ b/src/watch/migrate.rs
@@ -56,7 +56,7 @@ impl Migrator {
                     match branch {
                         Some(current_branch) if &current_branch != git_branch => {
                             print::error!(
-                                "Current git branch ({current_branch}) is different from the branch used to create the database ({git_branch}), exiting watch mode"
+                                "Current git branch ({current_branch}) is different from the branch used to start watch mode ({git_branch}), exiting."
                             );
                             std::process::exit(1);
                         }

--- a/src/watch/migrate.rs
+++ b/src/watch/migrate.rs
@@ -6,31 +6,35 @@ use const_format::concatcp;
 use edgeql_parser::helpers::quote_string;
 use gel_tokio::Error;
 use indicatif::ProgressBar;
+use log::debug;
 use tokio::sync::mpsc::UnboundedReceiver;
 
 use crate::branding::BRANDING_CLI_CMD;
 use crate::connect::{Connection, Connector};
 use crate::migrations::{self, dev_mode};
-use crate::print;
+use crate::{git, msg, print};
 
 use super::{Context, ExecutionOrder, Watcher};
 
 pub struct Migrator {
     ctx: Arc<Context>,
     migration_ctx: migrations::Context,
-
+    git_branch: Option<String>,
     connector: Connector,
     is_force_database_error: bool,
 }
 
 impl Migrator {
     pub async fn new(ctx: Arc<Context>) -> anyhow::Result<Self> {
+        let git_branch = git::git_current_branch().await;
+
         let connector = ctx.options.create_connector().await?;
         Ok(Migrator {
             migration_ctx: migrations::Context::for_project(
                 ctx.project.clone(),
                 ctx.options.skip_hooks,
             )?,
+            git_branch,
             ctx,
             connector,
             is_force_database_error: false,
@@ -43,6 +47,35 @@ impl Migrator {
         matcher: Arc<Watcher>,
     ) {
         loop {
+            if let Some(git_branch) = &self.git_branch {
+                let mut first_detatched = true;
+                debug!("Expecting git branch: {}", git_branch);
+                loop {
+                    let branch = git::git_current_branch().await;
+                    debug!("Current git branch: {:?}", branch);
+                    match branch {
+                        Some(current_branch) if &current_branch != git_branch => {
+                            print::error!(
+                                "Current git branch ({current_branch}) is different from the branch used to create the database ({git_branch}), exiting watch mode"
+                            );
+                            std::process::exit(1);
+                        }
+                        Some(..) if !first_detatched => {
+                            msg!("Repository is no longer detached, resuming watch mode");
+                            break;
+                        }
+                        Some(..) => break,
+                        None if first_detatched => {
+                            msg!("Repository HEAD is detached, pausing watch mode");
+                            first_detatched = false;
+                            continue;
+                        }
+                        None => {
+                            tokio::time::sleep(Duration::from_secs(1)).await;
+                        }
+                    }
+                }
+            }
             let res = self.migration_apply_dev_mode().await;
 
             if let Err(e) = &res {

--- a/src/watch/migrate.rs
+++ b/src/watch/migrate.rs
@@ -61,12 +61,12 @@ impl Migrator {
                             std::process::exit(1);
                         }
                         Some(..) if !first_detatched => {
-                            msg!("Repository is no longer detached, resuming watch mode");
+                            msg!("git repository is no longer detached, resuming watch mode");
                             break;
                         }
                         Some(..) => break,
                         None if first_detatched => {
-                            msg!("Repository HEAD is detached, pausing watch mode");
+                            msg!("git repository HEAD is detached, pausing watch mode");
                             first_detatched = false;
                             continue;
                         }

--- a/tests/scripts/project/watch.cli
+++ b/tests/scripts/project/watch.cli
@@ -4,32 +4,9 @@ $ gel instance destroy -I watch_test --force
 %EXIT any
 *
 
-$ mktemp -d
-%SET WORK_DIR
-*
+using tempdir;
 
-defer {
-    $ cat /tmp/log
-    *
-}
-
-defer {
-    $ rm -rf $WORK_DIR
-}
-
-if TARGET_OS == "windows" {
-    # Because mktemp is MINGW and doesn't use real windows paths, we need to
-    # set PWD using the translated path.
-    $ mkdir $WORK_DIR/watch_test && cmd //c echo "%WORK_DIR%/watch_test" 2> /dev/null
-    %SET PWD
-    *
-}
-
-if TARGET_OS != "windows" {
-    $ mkdir $WORK_DIR/watch_test && echo "$WORK_DIR/watch_test"
-    %SET PWD
-    *
-}
+using new dir "watch_test";
 
 $ gel project init --instance=watch_test --non-interactive
 *
@@ -109,8 +86,7 @@ $ gel query "select schema::Migration {*} filter .generated_by =
 
 $ sleep 1
 
-# This seems to be racing with gel watch
-$ gel migrate --dev-mode 2> /tmp/log
+$ gel migrate --dev-mode
 *
 
 $ sleep 1


### PR DESCRIPTION
If the branch changes during `gel watch`, we exit watch mode.

```
Hint: --migrate will apply any changes from your schema files to the database. When ready to commit your changes, use:
1) `gel migration create` to write those changes to a migration file,
2) `gel migrate --dev-mode` to replace all synced changes with the migration.

Monitoring /devel/github/edgedb-cli for changes in:

  --migrate: gel migration apply --dev-mode

Schema up to date.
--- --migrate: gel migration apply --dev-mode ---
gel error: Current git branch (git_branch2) is different from the branch used to start watch mode (git_branch), exiting.
```

If the current directory becomes a disconnected head, we pause watch and wait for the branch to return (possibly because a `git rebase` is in progress).

```
Hint: --migrate will apply any changes from your schema files to the database. When ready to commit your changes, use:
1) `gel migration create` to write those changes to a migration file,
2) `gel migrate --dev-mode` to replace all synced changes with the migration.

Monitoring /devel/github/edgedb-cli for changes in:

  --migrate: gel migration apply --dev-mode

Schema up to date.
--- --migrate: gel migration apply --dev-mode ---
git repository HEAD is detached, pausing watch mode
git repository is no longer detached, resuming watch mode
Schema up to date.
```