### PR TITLE
Don't set force_database_error in watch

### DIFF
--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -23,8 +23,6 @@ use crate::print::{self, AsRelativeToCurrentDir, Highlight};
 #[derive(clap::Args, Debug, Clone)]
 pub struct Command {
     /// Runs "[BRANDING_CLI_CMD] migration apply --dev-mode" on changes to schema definitions.
-    /// On migration errors `force_database_error` is set, which rejects all queries
-    /// to the database. This configuration is cleared when the error is resolved or watch is stopped.
     ///
     /// This runs in addition to to scripts in [MANIFEST_FILE_DISPLAY_NAME].
     #[arg(short = 'm', long)]

--- a/tests/func/interactive.rs
+++ b/tests/func/interactive.rs
@@ -87,40 +87,6 @@ limit = 3
 }
 
 #[test]
-fn force_database_error() {
-    SERVER
-        .admin_cmd()
-        .arg("database")
-        .arg("create")
-        .arg("error_test")
-        .assert()
-        .context("create", "create new database")
-        .success();
-
-    SERVER
-        .admin_cmd()
-        .arg("query")
-        .arg("--database=error_test")
-        .arg(
-            r#"configure current database
-                set force_database_error :=
-                  '{"type": "QueryError", "message": "ongoing maintenance"}';
-            "#,
-        )
-        .assert()
-        .context("set force_database_error", "should succeed")
-        .success();
-
-    let mut cmd = SERVER.custom_interactive(|cmd| {
-        cmd.arg("--database=error_test");
-    });
-    cmd.exp_string("error_test>").unwrap();
-    cmd.send_line("configure current database reset force_database_error;")
-        .unwrap();
-    cmd.exp_string("error_test>").unwrap();
-}
-
-#[test]
 fn warnings() {
     let mut cmd = SERVER.admin_interactive();
     let main = SERVER.default_branch();

--- a/tests/func/non_interactive.rs
+++ b/tests/func/non_interactive.rs
@@ -365,45 +365,6 @@ fn hash_password() {
 }
 
 #[test]
-fn force_database_error() {
-    SERVER
-        .admin_cmd()
-        .arg("database")
-        .arg("create")
-        .arg("error_test2")
-        .assert()
-        .context("create", "create new database")
-        .success();
-
-    SERVER
-        .admin_cmd()
-        .arg("query")
-        .arg("--database=error_test2")
-        .arg(
-            r#"configure current database
-                set force_database_error :=
-                  '{"type": "QueryError", "message": "ongoing maintenance"}';
-            "#,
-        )
-        .assert()
-        .context("set force_database_error", "should succeed")
-        .success();
-
-    SERVER
-        .admin_cmd()
-        .arg("query")
-        .arg("--database=error_test2")
-        .arg(
-            r#"configure current database
-                reset force_database_error;
-            "#,
-        )
-        .assert()
-        .context("reset force_database_error", "should succeed")
-        .success();
-}
-
-#[test]
 fn warnings() {
     SERVER
         .admin_cmd()


### PR DESCRIPTION
`force_database_error` is breaking dev workflows, this is the first step of its deprecation and drop.