### PR TITLE
Clear `WatchError` on sight

### DIFF
--- a/src/migrations/apply.rs
+++ b/src/migrations/apply.rs
@@ -29,17 +29,6 @@ use crate::migrations::timeout;
 use crate::options::ConnectionOptions;
 use crate::print::{self, Highlight};
 
-pub async fn run(
-    cmd: &Command,
-    conn: &mut Connection,
-    options: &Options,
-) -> Result<(), anyhow::Error> {
-    let old_state = conn.set_ignore_error_state();
-    let res = run_inner(cmd, conn, options).await;
-    conn.restore_state(old_state);
-    res
-}
-
 #[derive(clap::Args, Clone, Debug)]
 pub struct Command {
     #[command(flatten)]
@@ -82,7 +71,7 @@ pub struct Command {
     pub single_transaction: bool,
 }
 
-async fn run_inner(
+pub async fn run(
     cmd: &Command,
     conn: &mut Connection,
     options: &Options,

--- a/src/migrations/create.rs
+++ b/src/migrations/create.rs
@@ -47,10 +47,7 @@ pub async fn run(cmd: &Command, conn: &mut Connection, options: &Options) -> any
     if cmd.squash {
         squash::run(cmd, conn, options).await
     } else {
-        let old_state = conn.set_ignore_error_state();
-        let res = run_inner(cmd, conn, options).await;
-        conn.restore_state(old_state);
-        res
+        run_inner(cmd, conn, options).await
     }
 }
 

--- a/src/migrations/edit.rs
+++ b/src/migrations/edit.rs
@@ -121,13 +121,6 @@ async fn check_migration(cli: &mut Connection, text: &str, path: &Path) -> anyho
 }
 
 pub async fn edit(cli: &mut Connection, cmd: &MigrationEdit, opts: &Options) -> anyhow::Result<()> {
-    let old_state = cli.set_ignore_error_state();
-    let res = _edit(cli, cmd, opts).await;
-    cli.restore_state(old_state);
-    res
-}
-
-async fn _edit(cli: &mut Connection, cmd: &MigrationEdit, opts: &Options) -> anyhow::Result<()> {
     let ctx = Context::for_migration_config(&cmd.cfg, false, opts.skip_hooks, false).await?;
     // TODO(tailhook) do we have to make the full check of whether there are no
     // gaps and parent revisions are okay?

--- a/src/migrations/log.rs
+++ b/src/migrations/log.rs
@@ -21,17 +21,6 @@ pub async fn log(
 
 pub async fn log_db(
     conn: &mut Connection,
-    common: &Options,
-    options: &MigrationLog,
-) -> Result<(), anyhow::Error> {
-    let old_state = conn.set_ignore_error_state();
-    let res = _log_db(conn, common, options).await;
-    conn.restore_state(old_state);
-    res
-}
-
-async fn _log_db(
-    conn: &mut Connection,
     _common: &Options,
     options: &MigrationLog,
 ) -> Result<(), anyhow::Error> {


### PR DESCRIPTION
~This is a follow-up of #1626 to totally forget `force_database_error`. This is a separate PR because we still want e.g. `gel migrate` to fail properly in the transition period when a concurrent legacy `gel watch` set `force_database_error`.~

Per @vpetrovykh 's suggestion, this PR actively clears `WatchError` on sight, and no longer sets `force_database_error` in the session config.