### PR TITLE
bugfix: gel init with Cloud instance

### DIFF
--- a/src/portable/project/mod.rs
+++ b/src/portable/project/mod.rs
@@ -196,7 +196,7 @@ impl Handle<'_> {
                 }),
             },
             InstanceName::Cloud(name) => Ok(Handle {
-                name: name.name.clone(),
+                name: name.to_string(),
                 instance: InstanceKind::Cloud {
                     name: name.clone(),
                     cloud_client,


### PR DESCRIPTION
Fixes the following bug refs #1579:

```
$ gel init
Found `gel.toml` in /home/fantix/edgedb-cli
Initializing project...
Specify the name of the Gel instance to use with this project [default: edgedb_cli_7454]:
> fantix/mydb
Do you want to use existing instance "fantix/mydb" for the project? [y/n]
> y
gel error: InvalidArgumentError: Credentials file not found
```

This fix is manually verified.