### PR TITLE
Add `--extend-gel-toml` to `gel watch` command

### DIFF
--- a/src/portable/project/init.rs
+++ b/src/portable/project/init.rs
@@ -636,6 +636,7 @@ fn init_new(
             },
             project: None,
             hooks: None,
+            hooks_extend: None,
             watch: Vec::new(),
         };
         project::manifest::write(&location.manifest, &manifest)?;
@@ -701,6 +702,7 @@ fn init_new(
                 },
                 project: Default::default(),
                 hooks: None,
+                hooks_extend: None,
                 watch: Vec::new(),
             };
             project::manifest::write(&location.manifest, &manifest)?;
@@ -767,6 +769,7 @@ fn init_new(
                 },
                 project: Default::default(),
                 hooks: None,
+                hooks_extend: None,
                 watch: Vec::new(),
             };
 

--- a/src/portable/project/mod.rs
+++ b/src/portable/project/mod.rs
@@ -348,6 +348,14 @@ impl Context {
         })
     }
 
+    pub fn read_extended(self, path: &Path) -> anyhow::Result<Context> {
+        let Context { manifest, .. } = self;
+        Ok(Context {
+            manifest: manifest.read_extended(path)?,
+            ..self
+        })
+    }
+
     pub fn downgrade_instance_lock(&self) -> anyhow::Result<()> {
         if let Some(lock) = &self.instance_lock {
             Ok(lock.downgrade()?)

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -7,6 +7,7 @@ pub use scripts::run_script;
 
 use std::collections::HashSet;
 use std::iter::FromIterator;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use tokio::sync::mpsc::error::TryRecvError;
@@ -35,6 +36,9 @@ pub struct Command {
     /// Do not exit when the parent process exits.
     #[arg(long)]
     pub no_exit_with_parent: bool,
+
+    #[arg(long)]
+    pub extend_gel_toml: Option<PathBuf>,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -44,6 +48,9 @@ pub async fn run(options: &Options, cmd: &Command) -> anyhow::Result<()> {
     let mut project = project::ensure_ctx_async(None).await?;
     project.downgrade_instance_lock()?;
     project.drop_project_lock();
+    if let Some(extend_gel_toml) = &cmd.extend_gel_toml {
+        project = project.read_extended(extend_gel_toml)?
+    }
 
     let ctx = Arc::new(Context {
         project,


### PR DESCRIPTION
This option allows specifying an extra TOML file with additional hooks to extend the default `gel.toml`.

Before hooks will run in order: `gel.toml` -> extended TOML
After hooks will run in order: extended TOML -> `gel.toml`

This is to support (3) in geldata/gel-python#647