### PR TITLE
Make `gel init` non-interactive by default

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -528,6 +528,7 @@ fn try_project_init(opts: Option<&crate::options::Options>) -> anyhow::Result<In
             server_instance: None,
             database: None,
             non_interactive: false,
+            interactive: true,
             no_migrations: false,
             link: false,
             server_start_conf: None,


### PR DESCRIPTION
1. `gel init` is now non-interactive by default
2. So is `gel project init`
3. `--non-interactive` on the `init` command is now a no-op
4. To recover old behavior, use `gel init --interactive`