### PR TITLE
Use cargo-install action for `clitest`

### DIFF
--- a/.github/workflows/new-tests.yml
+++ b/.github/workflows/new-tests.yml
@@ -96,7 +96,7 @@ jobs:
         uses: baptiste0928/cargo-install@91c5da15570085bcde6f4d7aed98cb82d6769fd3
         with:
           crate: clitest
-          version: '=0.1.20'
+          version: '=0.1.21'
 
       - name: Download artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/new-tests.yml
+++ b/.github/workflows/new-tests.yml
@@ -64,41 +64,11 @@ jobs:
           RUSTFLAGS="-C target-feature=+crt-static" cargo build --target=x86_64-unknown-linux-gnu
           cp target/x86_64-unknown-linux-gnu/debug/gel target/debug/gel
 
-      - name: Download clitest from cache
-        id: clitest-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.CARGO_HOME }}/bin/clitest*
-          key: clitest-${{ env.CACHE_KEY }}-${{ runner.os }}
-          restore-keys: |
-            clitest-${{ env.CACHE_KEY }}-${{ runner.os }}-
-
-      - name: Build clitest
-        if: steps.clitest-cache.outputs.cache-hit != 'true'
-        run: |
-          cargo install clitest
-
-      - name: Upload clitest to cache
-        if: steps.clitest-cache.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.CARGO_HOME }}/bin/clitest*
-          key: clitest-${{ env.CACHE_KEY }}-${{ runner.os }}
-          restore-keys: |
-            clitest-${{ env.CACHE_KEY }}-${{ runner.os }}-
-
       - name: Upload artifacts (gel)
         uses: actions/upload-artifact@v4
         with:
           name: debug-gel-cli-${{ runner.os }}
           path: target/debug/gel*
-          if-no-files-found: error
-
-      - name: Upload artifacts (clitest)
-        uses: actions/upload-artifact@v4
-        with:
-          name: debug-clitest-${{ runner.os }}
-          path: ${{ env.CARGO_HOME }}/bin/clitest*
           if-no-files-found: error
 
   tests:
@@ -121,6 +91,12 @@ jobs:
         with:
           components: "cargo,rustc,rust-std"
           toolchain: '1.85'
+
+      - name: Install clitest from crates.io
+        uses: baptiste0928/cargo-install@91c5da15570085bcde6f4d7aed98cb82d6769fd3
+        with:
+          crate: clitest
+          version: '=0.1.20'
 
       - name: Download artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/new-tests.yml
+++ b/.github/workflows/new-tests.yml
@@ -112,7 +112,6 @@ jobs:
       - name: Copy artifacts to PATH
         run: |
           cp artifacts/debug-gel-cli-${{ runner.os }}/gel* ${{ env.CARGO_HOME }}/bin/
-          cp artifacts/debug-clitest-${{ runner.os }}/clitest* ${{ env.CARGO_HOME }}/bin/
 
       - name: Setup WSL
         if: runner.os == 'Windows'


### PR DESCRIPTION
We're overcomplicating the install of clitest -- let's just use `cargo-install` rather than trying to build it ourselves which is fraught with peril.