### PR TITLE
Improve gel project info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1682,15 +1682,14 @@ dependencies = [
 
 [[package]]
 name = "gel-dsn"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0c27dda7e5d5e1364552ba8912b2c247c3c63c08189987c17e7fda927280c2"
+checksum = "6ff42d62265e679b2012abc67fe85547881716e833de9b0cfded3f7cdf2e58c5"
 dependencies = [
  "base64 0.22.1",
  "crc16",
  "derive_more",
  "dirs",
- "gel-auth",
  "gel-errors",
  "gel-stream",
  "log",
@@ -1701,7 +1700,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "thiserror 2.0.12",
  "url",
  "whoami",
 ]

--- a/src/portable/project/info.rs
+++ b/src/portable/project/info.rs
@@ -16,7 +16,7 @@ pub fn run(options: &Command) -> anyhow::Result<()> {
     let dir = options
         .project_dir
         .clone()
-        .map(ProjectDir::Exact)
+        .map(ProjectDir::Search)
         .unwrap_or_else(|| ProjectDir::SearchCwd);
     let result = gel_tokio::dsn::ProjectSearchResult::find(dir)?
         .and_then(|m| m.project.map(|p| (p, m.project_path)));

--- a/src/portable/project/info.rs
+++ b/src/portable/project/info.rs
@@ -43,11 +43,14 @@ pub fn run(options: &Command) -> anyhow::Result<()> {
         }
         DatabaseBranch::Default => {
             // If the project doesn't have a database, get it from the instance.
-            let config = gel_tokio::dsn::Builder::new()
-                .without_system()
-                .with_fs()
-                .with_auto_project_cwd()
-                .build()?;
+            let builder = gel_tokio::dsn::Builder::new().without_system().with_fs();
+
+            let config = if let Some(project_dir) = options.project_dir.clone() {
+                builder.with_project_dir(project_dir).build()?
+            } else {
+                builder.with_auto_project_cwd().build()?
+            };
+
             match config.db {
                 DatabaseBranch::Database(database) => {
                     data.insert("database", database);

--- a/src/portable/project/info.rs
+++ b/src/portable/project/info.rs
@@ -13,7 +13,12 @@ use crate::print::{self, Highlight, msg};
 use crate::table;
 
 pub fn run(options: &Command) -> anyhow::Result<()> {
-    let result = gel_tokio::dsn::ProjectSearchResult::find(ProjectDir::SearchCwd)?
+    let dir = options
+        .project_dir
+        .clone()
+        .map(ProjectDir::Exact)
+        .unwrap_or_else(|| ProjectDir::SearchCwd);
+    let result = gel_tokio::dsn::ProjectSearchResult::find(dir)?
         .and_then(|m| m.project.map(|p| (p, m.project_path)));
 
     let Some((project, project_path)) = result else {

--- a/src/portable/project/info.rs
+++ b/src/portable/project/info.rs
@@ -38,7 +38,11 @@ pub fn run(options: &Command) -> anyhow::Result<()> {
         }
         DatabaseBranch::Default => {
             // If the project doesn't have a database, get it from the instance.
-            let config = gel_tokio::dsn::Builder::new().without_system().with_fs().with_auto_project_cwd().build()?;
+            let config = gel_tokio::dsn::Builder::new()
+                .without_system()
+                .with_fs()
+                .with_auto_project_cwd()
+                .build()?;
             match config.db {
                 DatabaseBranch::Database(database) => {
                     data.insert("database", database);

--- a/src/portable/project/info.rs
+++ b/src/portable/project/info.rs
@@ -16,7 +16,7 @@ pub fn run(options: &Command) -> anyhow::Result<()> {
     let dir = options
         .project_dir
         .clone()
-        .map(ProjectDir::Search)
+        .map(ProjectDir::NoSearch)
         .unwrap_or_else(|| ProjectDir::SearchCwd);
     let result = gel_tokio::dsn::ProjectSearchResult::find(dir)?
         .and_then(|m| m.project.map(|p| (p, m.project_path)));
@@ -46,7 +46,7 @@ pub fn run(options: &Command) -> anyhow::Result<()> {
             let builder = gel_tokio::dsn::Builder::new().without_system().with_fs();
 
             let config = if let Some(project_dir) = options.project_dir.clone() {
-                builder.with_project_dir(project_dir).build()?
+                builder.with_explicit_project(project_dir).build()?
             } else {
                 builder.with_auto_project_cwd().build()?
             };

--- a/src/portable/project/info.rs
+++ b/src/portable/project/info.rs
@@ -70,7 +70,7 @@ pub fn run(options: &Command) -> anyhow::Result<()> {
     }
     data.insert("instance-name", project.instance_name.to_string());
     if let Some(parent) = project_path.parent() {
-        data.insert("root", parent.canonicalize()?.display().to_string());
+        data.insert("root", parent.display().to_string());
 
         // TODO: this should be moved to gel-dsn
         let manifest = manifest::read(&project_path)?;

--- a/tests/scripts/link/script.cli
+++ b/tests/scripts/link/script.cli
@@ -16,8 +16,8 @@ pattern VERSION (\d+\.\d+(?:\.\d+)?(?:-(?:alpha|beta|rc|dev)\.\d+)?\+(?:[a-f0-9]
 
 ignore {
     ? Newer version of gel tool exists %{VERSION} \(current %{VERSION}\). To upgrade run `gel cli upgrade`
-    ! [edgedb] WARNING %{GREEDYDATA} postgres: %{GREEDYDATA}
-    ! [edgedb] CRITICAL %{GREEDYDATA} postgres: %{GREEDYDATA}
+    ! WARNING %{GREEDYDATA} postgres: %{GREEDYDATA}
+    ! CRITICAL %{GREEDYDATA} postgres: %{GREEDYDATA}
     ! Connecting to Gel instance '%{DATA}' at %{HOSTPORT}...
 }
 

--- a/tests/scripts/project/hooks.cli
+++ b/tests/scripts/project/hooks.cli
@@ -1,10 +1,8 @@
 #!/usr/bin/env clitest --v0
 
-$ mktemp -d
-%SET WORK_DIR
-*
+using tempdir;
 
-$ cp -R ../../proj $WORK_DIR
+$ cp -R $INITIAL_PWD/../../proj .
 *
 
 $ gel instance destroy -I inst2 --force
@@ -15,8 +13,10 @@ $ gel instance destroy -I inst2 --force
 $ gel instance create inst2 default-branch-name --non-interactive
 *
 
+cd proj/project3;
+
 # Initialize project
-$ cd $WORK_DIR/proj/project3 && gel project init --link --server-instance=inst2 --non-interactive
+$ gel project init --link --server-instance=inst2 --non-interactive
 reject {
     # Reject any hooks that are not listed below
     ? hook (?!project.init.after|migration.apply.before|schema.update.before|migration.apply.after|schema.update.after): %{GREEDYDATA}
@@ -33,8 +33,16 @@ reject {
 ! hook schema.update.after: true
 *
 
+$ gel project info --json
+! {
+!   "branch": "default-branch-name",
+!   "instance-name": "inst2",
+!   "root": "%{PATH}",
+!   "schema-dir": "%{PATH}/database_schema"
+! }
+
 # Switch to a new branch
-$ cd $WORK_DIR/proj/project3 && gel branch switch --create --empty another
+$ gel branch switch --create --empty another
 reject {
     # Reject any hooks that are not listed below
     ? hook (?!branch.switch.before|branch.switch.after|schema.update.before|schema.update.after): %{GREEDYDATA}
@@ -50,11 +58,11 @@ reject {
 *
 
 # Verify branch log
-$ cat $WORK_DIR/proj/project3/branch.log
+$ cat branch.log
 ! another
 
 # Merge branch
-$ cd $WORK_DIR/proj/project3 && gel branch merge default-branch-name
+$ gel branch merge default-branch-name
 reject {
     # Reject any hooks that are not listed below
     ? hook (?!migration.apply.before|schema.update.before|migration.apply.after|schema.update.after): %{GREEDYDATA}
@@ -70,7 +78,7 @@ reject {
 *
 
 # Wipe branch
-$ cd $WORK_DIR/proj/project3 && gel branch wipe another --non-interactive
+$ gel branch wipe another --non-interactive
 reject {
     # Reject any hooks that are not listed below
     ? hook (?!branch.wipe.before|schema.update.before|branch.wipe.after|schema.update.after): %{GREEDYDATA}
@@ -86,7 +94,7 @@ reject {
 *
 
 # Switch back to default branch
-$ cd $WORK_DIR/proj/project3 && gel branch switch default-branch-name
+$ gel branch switch default-branch-name
 reject {
     # Reject any hooks that are not listed below
     ? hook (?!branch.switch.before|schema.update.before|branch.switch.after|schema.update.after): %{GREEDYDATA}
@@ -102,26 +110,26 @@ reject {
 *
 
 # Verify branch log again
-$ cat $WORK_DIR/proj/project3/branch.log
+$ cat branch.log
 ! another
 ! default-branch-name
 
 # Test branch switch with --instance flag (should not trigger hooks)
-$ cd $WORK_DIR/proj/project3 && gel --instance=inst2 branch switch another
+$ gel --instance=inst2 branch switch another
 reject {
     ! hook %{GREEDYDATA}
 }
 *
 
 # Test branch switch with --skip-hooks flag
-$ cd $WORK_DIR/proj/project3 && gel --skip-hooks branch switch another
+$ gel --skip-hooks branch switch another
 reject {
     ! hook %{GREEDYDATA}
 }
 *
 
 # Test branch switch with GEL_SKIP_HOOKS environment variable
-$ cd $WORK_DIR/proj/project3 && GEL_SKIP_HOOKS=1 gel branch switch default-branch-name
+$ GEL_SKIP_HOOKS=1 gel branch switch default-branch-name
 reject {
     ! hook %{GREEDYDATA}
 }

--- a/tests/scripts/project/hooks.cli
+++ b/tests/scripts/project/hooks.cli
@@ -37,8 +37,8 @@ $ gel project info --json
 ! {
 !   "branch": "default-branch-name",
 !   "instance-name": "inst2",
-!   "root": "%{PATH}",
-!   "schema-dir": "%{PATH}/database_schema"
+!   "root": "%{GREEDYDATA}",
+!   "schema-dir": "%{GREEDYDATA}database_schema"
 ! }
 
 # Switch to a new branch

--- a/tests/shared-client-tests/build.rs
+++ b/tests/shared-client-tests/build.rs
@@ -65,7 +65,7 @@ fn main() {
         ),
         (
             "multiple_compound_env",
-            "Multiple compound environment variables",
+            "Multiple compound options were specified while parsing environment variables",
         ),
         (
             "exclusive_options",


### PR DESCRIPTION
Use the new `gel-dsn` APIs for reading (most) of `gel project info`, which allows us to more easily add database/branch to this output.

We'll look to the instance credentials to get a branch/database if the project doesn't have one.
