### PR TITLE
`gel init` with `dbschema/extensions.gel`

### DIFF
--- a/src/portable/project/mod.rs
+++ b/src/portable/project/mod.rs
@@ -75,14 +75,18 @@ pub enum Subcommands {
 const EXT_AUTH_SCHEMA: &str = "\
     # Gel Auth is a batteries-included authentication solution\n\
     # for your app built into the Gel server.\n\
+    #\n\
     # See: https://docs.geldata.com/reference/auth\n\
+    #\n\
     #using extension auth;\n\
 ";
 
 const EXT_AI_SCHEMA: &str = "\
     # Gel AI is a set of tools designed to enable you to ship\n\
     # AI-enabled apps with practically no effort.\n\
+    #\n\
     # See: https://docs.geldata.com/reference/ai\n\
+    #\n\
     #using extension ai;\n\
 ";
 
@@ -92,10 +96,13 @@ const EXT_POSTGIS_SCHEMA: &str = "\
     # geographic and various geometric data. The scope of the Gel\n\
     # extension is to mainly adapt the types and functions used in\n\
     # this library with minimal changes.\n\
+    #\n\
     # See: https://docs.geldata.com/reference/stdlib/postgis\n\
+    #\n\
     # `ext::postgis` is not installed by default, use the command\n\
     # `gel extension` to manage its installation, then uncomment\n\
     # the line below to enable it.\n\
+    #\n\
     #using extension postgis;\n\
 ";
 
@@ -318,14 +325,17 @@ fn write_schema_default(dir: &Path, version: &Query) -> anyhow::Result<()> {
         extensions.push(EXT_POSTGIS_SCHEMA);
     }
     if !extensions.is_empty() {
-        extensions.insert(0, "\
+        extensions.insert(
+            0,
+            "\
             # This file contains Gel extensions used by the project.\n\
             # Uncomment the `using extension ...` below to enable them.\n\
-        ");
+        ",
+        );
         let ext_file = dir.join(format!("extensions.{BRANDING_SCHEMA_FILE_EXT}"));
         let tmp = tmp_file_path(&ext_file);
         fs::remove_file(&tmp).ok();
-        fs::write(&tmp, extensions.join("\n"))?;
+        fs::write(&tmp, extensions.join("\n\n"))?;
         fs::rename(&tmp, &ext_file)?;
     }
 

--- a/src/portable/repository.rs
+++ b/src/portable/repository.rs
@@ -720,6 +720,15 @@ impl Query {
     pub fn is_simple_scoping_needed(&self) -> bool {
         self.version.as_ref().map(|f| f.major == 6).unwrap_or(false)
     }
+    pub fn has_ext_auth(&self) -> bool {
+        self.version.as_ref().map(|f| f.major >= 4).unwrap_or(true)
+    }
+    pub fn has_ext_ai(&self) -> bool {
+        self.version.as_ref().map(|f| f.major >= 5).unwrap_or(true)
+    }
+    pub fn has_ext_postgis(&self) -> bool {
+        self.version.as_ref().map(|f| f.major >= 6).unwrap_or(false)
+    }
     pub fn cli_channel(&self) -> Option<Channel> {
         // Only one argument in CLI is allowed
         // So we skip channel if version is set, since version unambiguously


### PR DESCRIPTION
This PR makes `gel init` create a new file `dbschema/extensions.gel` like below, along with `dbschema/default.gel`:

```
# This file contains Gel extensions used by the project.
# Uncomment the `using extension ...` below to enable them.


# Gel Auth is a batteries-included authentication solution
# for your app built into the Gel server.
#
# See: https://docs.geldata.com/reference/auth
#
#using extension auth;


# Gel AI is a set of tools designed to enable you to ship
# AI-enabled apps with practically no effort.
#
# See: https://docs.geldata.com/reference/ai
#
#using extension ai;


# The `ext::postgis` extension exposes the functionality of the 
# PostGIS library. It is a vast library dedicated to handling
# geographic and various geometric data. The scope of the Gel
# extension is to mainly adapt the types and functions used in
# this library with minimal changes.
#
# See: https://docs.geldata.com/reference/stdlib/postgis
#
# `ext::postgis` is not installed by default, use the command
# `gel extension` to manage its installation, then uncomment
# the line below to enable it.
#
#using extension postgis;
```

Depending on the selected server version, this file may currently contain 1-3 extensions, all of which are commented out by default.

Refs #1665