### PR TITLE
Creating indexes with `build_concurrently`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745333101,
-        "narHash": "sha256-gplyD/oTr7JmrLoLllAVn+WIoF1ZYgNhVA10siXLWeI=",
+        "lastModified": 1750982477,
+        "narHash": "sha256-x9JM22KIrz6TEFN8ZPQiwuttw3FasAbFXu03Xs8Xvno=",
         "owner": "edgedb",
         "repo": "packages-nix",
-        "rev": "cd77b4fd3347b9c0ff6faffa5d45fc765e0b3536",
+        "rev": "e04d98b658004768d4b1b6c3d28a16d230c74b08",
         "type": "github"
       },
       "original": {
@@ -47,11 +47,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1745303921,
-        "narHash": "sha256-zYucemS2QvJUR5GKJ/u3eZAoe82AKhcxMtNVZDERXsw=",
+        "lastModified": 1751006353,
+        "narHash": "sha256-icKFXb83uv2ezRCfuq5G8QSwCuaoLywLljSL+UGmPPI=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "14850d5984f3696a2972f85f19085e5fb46daa95",
+        "rev": "b37f026b49ecb295a448c96bcbb0c174c14fc91b",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1743550720,
-        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "lastModified": 1749398372,
+        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745332728,
-        "narHash": "sha256-bkZBSXLYLuO08axj6Deug4h3gLEu5kZmCbEJp8lWx1Q=",
+        "lastModified": 1751035100,
+        "narHash": "sha256-N4Xgqf0JzcdYQeicPNt3kDoDvL2U911K7V4kbx7lHTE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2110ff3288c8ef11f7013ca01ca957fbcd1041d3",
+        "rev": "ccc919c55a1dc9908029761c8d6059a233093361",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1743296961,
-        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "lastModified": 1748740939,
+        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,10 @@
         }:
         let
           fenix_pkgs = fenix.packages.${system};
+          rust_toolchain = fenix_pkgs.toolchainOf {
+            channel = "1.85";
+            sha256 = "sha256-Hn2uaQzRLidAWpfmRwSRdImifGUCAb9HeAqTYFXWeQk=";
+          };
 
           common =
             [
@@ -57,15 +61,14 @@
         {
           devShells.default = pkgs.mkShell {
             buildInputs = common ++ [
-              (fenix_pkgs.combine [
-                (fenix_pkgs.fromToolchainFile {
-                  file = ./rust-toolchain.toml;
-                  sha256 = "sha256-Hn2uaQzRLidAWpfmRwSRdImifGUCAb9HeAqTYFXWeQk=";
-                })
-                (fenix_pkgs.targets.x86_64-unknown-linux-musl.fromToolchainFile {
-                  file = ./rust-toolchain.toml;
-                  sha256 = "sha256-Hn2uaQzRLidAWpfmRwSRdImifGUCAb9HeAqTYFXWeQk=";
-                })
+              (rust_toolchain.withComponents [
+                "rustc"
+                "cargo"
+                "rust-std"
+                "clippy"
+                "rustfmt"
+                "rust-src"
+                "rust-analyzer"
               ])
             ];
           };

--- a/src/migrations/apply.rs
+++ b/src/migrations/apply.rs
@@ -9,6 +9,7 @@ use gel_cli_instance::instance::backup::{
 use gel_protocol::common::{
     Capabilities, Cardinality, CompilationOptions, InputLanguage, IoFormat,
 };
+use gel_tokio::Queryable;
 use indexmap::IndexMap;
 use indicatif::{HumanBytes, ProgressBar};
 use tokio::fs;
@@ -71,6 +72,14 @@ pub struct Command {
     /// a regular `.edgeql` file, after which the above query will return nothing.
     #[arg(long)]
     pub dev_mode: bool,
+
+    /// Disable creation of concurrent indexes after applying migrations.
+    ///
+    /// Indexes that set `create_concurrently` to `true` are not activated when migration is applied.
+    /// Instead, they are activated right after, unless this flag is set. Index activation will
+    /// not acquire any locks that would prevent concurrent reads or writes of objects.
+    #[arg(long)]
+    pub no_index_activate: bool,
 
     /// Runs the migration(s) in a single transaction.
     #[arg(long = "single-transaction")]
@@ -174,6 +183,10 @@ pub async fn run(
     };
     let migrations = slice(&migrations, last_db_rev, target_rev.as_ref())?;
     if migrations.is_empty() {
+        if !cmd.no_index_activate {
+            index_activate_concurrently(conn).await?;
+        }
+
         if !cmd.quiet {
             eprintln!(
                 "{} Revision {}",
@@ -184,6 +197,7 @@ pub async fn run(
                     .emphasized(),
             );
         }
+
         return Ok(());
     }
     if !skip_auto_backup {
@@ -192,6 +206,11 @@ pub async fn run(
         }
     }
     apply_migrations(conn, migrations, &ctx, cmd.single_transaction).await?;
+
+    if !cmd.no_index_activate {
+        index_activate_concurrently(conn).await?;
+    }
+
     if db_migrations.is_empty() {
         disable_ddl(conn).await?;
     }
@@ -412,7 +431,7 @@ impl AsOperations for Vec<Operation<'_>> {
 }
 
 async fn fixup(
-    cli: &mut Connection,
+    conn: &mut Connection,
     ctx: &Context,
     migrations: &IndexMap<String, MigrationFile>,
     db_migrations: &IndexMap<String, DBMigration>,
@@ -516,7 +535,7 @@ async fn fixup(
         }
     }
 
-    apply_migrations(cli, &operations, ctx, _options.single_transaction).await?;
+    apply_migrations(conn, &operations, ctx, _options.single_transaction).await?;
     Ok(())
 }
 
@@ -649,7 +668,7 @@ fn backtrack<'a>(
 }
 
 pub async fn apply_migrations(
-    cli: &mut Connection,
+    conn: &mut Connection,
     migrations: &(impl AsOperations + ?Sized),
     ctx: &Context,
     single_transaction: bool,
@@ -661,29 +680,29 @@ pub async fn apply_migrations(
         }
     }
 
-    let old_timeout = timeout::inhibit_for_transaction(cli).await?;
+    let old_timeout = timeout::inhibit_for_transaction(conn).await?;
     {
         async_try! {
             async {
                 if single_transaction {
-                    execute(cli, "START TRANSACTION", None).await?;
+                    execute(conn, "START TRANSACTION", None).await?;
                     async_try! {
                         async {
-                            apply_migrations_inner(cli, migrations, !ctx.quiet).await
+                            apply_migrations_inner(conn, migrations, !ctx.quiet).await
                         },
                         except async {
-                            execute_if_connected(cli, "ROLLBACK").await
+                            execute_if_connected(conn, "ROLLBACK").await
                         },
                         else async {
-                            execute(cli, "COMMIT", None).await
+                            execute(conn, "COMMIT", None).await
                         }
                     }
                 } else {
-                    apply_migrations_inner(cli, migrations, !ctx.quiet).await
+                    apply_migrations_inner(conn, migrations, !ctx.quiet).await
                 }
             },
             finally async {
-                timeout::restore_for_transaction(cli, old_timeout).await
+                timeout::restore_for_transaction(conn, old_timeout).await
             }
         }
     }?;
@@ -695,7 +714,7 @@ pub async fn apply_migrations(
 }
 
 pub async fn apply_migration(
-    cli: &mut Connection,
+    conn: &mut Connection,
     migration: &MigrationFile,
     verbose: bool,
 ) -> anyhow::Result<()> {
@@ -713,7 +732,7 @@ pub async fn apply_migration(
         .await
         .context("error re-reading migration file")?;
 
-    let res = execute_with_parse_callback(cli, &data, || {
+    let res = execute_with_parse_callback(conn, &data, || {
         if verbose {
             eprintln!("... parsed");
         }
@@ -735,7 +754,7 @@ pub async fn apply_migration(
 }
 
 async fn execute_with_parse_callback(
-    cli: &mut Connection,
+    conn: &mut Connection,
     query: &str,
     after_parse: impl FnOnce(),
 ) -> Result<(), gel_errors::Error> {
@@ -750,38 +769,38 @@ async fn execute_with_parse_callback(
         expected_cardinality: Cardinality::Many,
     };
 
-    let command = cli.parse(&opts, query).await?;
+    let command = conn.parse(&opts, query).await?;
     after_parse();
-    let stream: ResponseStream<bool> = cli.execute_stream(&opts, query, &command, &()).await?;
+    let stream: ResponseStream<bool> = conn.execute_stream(&opts, query, &command, &()).await?;
     stream.complete().await?;
     Ok(())
 }
 
 pub async fn apply_migrations_inner(
-    cli: &mut Connection,
+    conn: &mut Connection,
     migrations: &(impl AsOperations + ?Sized),
     verbose: bool,
 ) -> anyhow::Result<()> {
     for operation in migrations.as_operations() {
         match operation {
             Operation::Apply(migration) => {
-                apply_migration(cli, migration, verbose).await?;
+                apply_migration(conn, migration, verbose).await?;
             }
             Operation::Rewrite(migrations) => {
-                execute(cli, "START MIGRATION REWRITE", None).await?;
+                execute(conn, "START MIGRATION REWRITE", None).await?;
                 async_try! {
                     async {
                         for migration in migrations.values() {
-                            apply_migration(cli, migration, false).await?;
+                            apply_migration(conn, migration, false).await?;
                         }
                         anyhow::Ok(())
                     },
                     except async {
-                        execute_if_connected(cli, "ABORT MIGRATION REWRITE")
+                        execute_if_connected(conn, "ABORT MIGRATION REWRITE")
                             .await
                     },
                     else async {
-                        execute(cli, "COMMIT MIGRATION REWRITE", None).await
+                        execute(conn, "COMMIT MIGRATION REWRITE", None).await
                             .context("commit migration rewrite")
                     }
                 }?;
@@ -791,8 +810,8 @@ pub async fn apply_migrations_inner(
     Ok(())
 }
 
-async fn disable_ddl(cli: &mut Connection) -> Result<(), anyhow::Error> {
-    let ddl_setting = cli
+async fn disable_ddl(conn: &mut Connection) -> Result<(), anyhow::Error> {
+    let ddl_setting = conn
         .query_required_single(
             r#"
         SELECT exists(
@@ -807,7 +826,7 @@ async fn disable_ddl(cli: &mut Connection) -> Result<(), anyhow::Error> {
         )
         .await?;
     if ddl_setting {
-        cli.execute(
+        conn.execute(
             r#"
             CONFIGURE CURRENT DATABASE SET allow_bare_ddl :=
                 cfg::AllowBareDDL.NeverAllow;
@@ -816,6 +835,43 @@ async fn disable_ddl(cli: &mut Connection) -> Result<(), anyhow::Error> {
         )
         .await?;
     }
+    Ok(())
+}
+
+async fn index_activate_concurrently(conn: &mut Connection) -> Result<(), anyhow::Error> {
+    #[derive(Queryable)]
+    struct IndexShort {
+        id: uuid::Uuid,
+        expr: String,
+        subject_name: String,
+    }
+
+    let inactive_indexes: Vec<IndexShort> = conn
+        .query(
+            "
+            select schema::Index {
+              id, expr, subject_name := .<indexes[is schema::ObjectType].name
+            }
+            filter .create_concurrently and not .active
+            ",
+            &(),
+        )
+        .await?;
+
+    for index in inactive_indexes {
+        print::msg!(
+            "Activating index on '{}' with expr '{}'",
+            index.subject_name.emphasized(),
+            index.expr
+        );
+        conn.execute(
+            &format!("administer concurrent_index_create(\"{}\")", index.id),
+            &(),
+        )
+        .await?;
+        print::msg!("... {}", "done".emphasized().success());
+    }
+
     Ok(())
 }
 

--- a/src/portable/project/init.rs
+++ b/src/portable/project/init.rs
@@ -1247,7 +1247,7 @@ async fn migrate_async(
             to_revision: None,
             dev_mode: false,
             single_transaction: false,
-            no_index_activate: false,
+            no_index_build: false,
             conn: None,
         },
         &mut conn,

--- a/src/portable/project/init.rs
+++ b/src/portable/project/init.rs
@@ -1247,6 +1247,7 @@ async fn migrate_async(
             to_revision: None,
             dev_mode: false,
             single_transaction: false,
+            no_index_activate: false,
             conn: None,
         },
         &mut conn,


### PR DESCRIPTION
Ref https://github.com/geldata/gel/pull/8747 and
https://github.com/geldata/gel/issues/8175

This is the command output:

```
Applying m174z6shgcp4npgznerch2iiyppimoi3ybrl3refoe3ruzbj65m7wa (00001-m174z6s.edgeql)
... parsed
... applied
Applying m1zieaot5h3ugqofzch2exrzxbs2mijqidzcbjgvuvs2356wzs6saa (00002-m1zieao.edgeql)
... parsed
... applied
Applying m1dhu7b2uuqssjt2i576s7enjs2qikyiomcgug4bjr35seddphxdkq (00003-m1dhu7b.edgeql)
... parsed
... applied
Activating index on 'default::B' with expr '.z'
... done
```

I've also added `--no-index-activate` flag:

```
      --no-index-activate
          Disable creation of concurrent indexes after applying migrations.

          Indexes that set `create_concurrently` to `true` are not activated when migration is
          applied. Instead, they are activated right after, unless this flag is set. Index
          activation will not acquire any locks that would prevent concurrent reads or writes of
          objects.
```
