### PR TITLE
Allow to choose upgrade method for Cloud

### DIFF
--- a/gel-cli-instance/src/cloud/schema.rs
+++ b/gel-cli-instance/src/cloud/schema.rs
@@ -183,7 +183,7 @@ pub struct CloudInstanceResize {
 #[derive(Debug, serde::Serialize)]
 pub struct CloudInstanceUpgrade {
     pub version: String,
-    pub force: bool,
+    pub use_dump_restore: Option<bool>,
 }
 
 #[derive(Debug, serde::Serialize)]

--- a/src/portable/project/upgrade.rs
+++ b/src/portable/project/upgrade.rs
@@ -90,6 +90,16 @@ pub struct Command {
     #[arg(long)]
     pub force: bool,
 
+    /// Force dump-restore upgrade method for Cloud instances.
+    #[arg(long)]
+    #[arg(conflicts_with = "force_in_place")]
+    pub force_dump_restore: bool,
+
+    /// Force in-place upgrade method for Cloud instances.
+    #[arg(long)]
+    #[arg(conflicts_with = "force_dump_restore")]
+    pub force_in_place: bool,
+
     /// Do not ask questions, assume user wants to upgrade instance
     #[arg(long)]
     pub non_interactive: bool,
@@ -312,6 +322,7 @@ fn upgrade_local(
                     verbose: false,
                     force: cmd.force,
                     force_dump_restore: cmd.force,
+                    force_in_place: false,
                     non_interactive: true,
                     cloud_opts: opts.cloud_options.clone(),
                 },
@@ -371,7 +382,14 @@ fn upgrade_cloud(
     let client = cloud::client::CloudClient::new(&opts.cloud_options)?;
     client.ensure_authenticated()?;
 
-    let result = upgrade::upgrade_cloud(name, to_version, &client, cmd.force, |target_ver| {
+    let use_dump_restore = match (cmd.force_dump_restore, cmd.force_in_place) {
+        (true, false) => Some(true),
+        (false, true) => Some(false),
+        (false, false) => None,
+        _ => unreachable!(), // should be prevented by Clap
+    };
+
+    let result = upgrade::upgrade_cloud(name, to_version, &client, use_dump_restore, |target_ver| {
         let target_ver_str = target_ver.to_string();
         let inst_name = name.to_string().emphasized();
         if !cmd.non_interactive {


### PR DESCRIPTION
We're going to enable in-place upgrade as a possible option for Cloud and we need support for this in the CLI. Additionally removes the behavior for `--force` flag for Cloud because it doesn't check it and will just return a message that the instance is already up-to-date

Closes #1570