### PR TITLE
`gel generate` use project-local tool only

### DIFF
--- a/src/commands/execute.rs
+++ b/src/commands/execute.rs
@@ -89,7 +89,7 @@ pub async fn common(
         // it as if it does so that we get the connection failed error
         // from the CLI instead of whichever binding.
         Generate(cmd) => {
-            generate::run(cmd, options).await?;
+            generate::run(cmd, options, "generate").await?;
         }
         Pgaddr => match conn.get_server_param::<PostgresAddress>() {
             Some(addr) => {


### PR DESCRIPTION
Instead of possibly running the wrong tool, always detect and run the local tool conservatively.

This means for Python:
 1. Detect virtual environment first, and only use the tool from it or fail
 2. Detect uv project, and rerun the same `gel generate` command with `uv run` for its venv
    * Must not use `uv run gel-generate-py` directly, because it might search in $PATH
 3. Fail with proper message otherwise

Fixes #1696 
Replaces #1699