### PR TITLE
Bump clitest and add justfile

### DIFF
--- a/.github/workflows/new-tests.yml
+++ b/.github/workflows/new-tests.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CACHE_KEY: 2
-  CLITEST_VERSION: "=0.1.26"
+  CLITEST_VERSION: "=0.1.29"
   RUST_VERSION: "1.85"
   RUST_COMPONENTS: "cargo,rustc,rust-std,clippy,rustfmt"
 

--- a/justfile
+++ b/justfile
@@ -3,9 +3,12 @@ test: cargo-test clitest
 cargo-test:
   cargo test
 
-# `just clitest` runs all tests, in quiet mode.
-# `just clitest <test1> <test2>` runs only the specified tests, in verbose mode.
-clitest *ARGS:
+cargo-build:
+  cargo build
+
+# just clitest runs all tests, in quiet mode.
+# just clitest {test1} {test2} runs only the specified tests, in verbose mode.
+clitest *ARGS: cargo-build
   #!/bin/bash
   set -euf -o pipefail
   CLITEST_VERSION=$(grep 'CLITEST_VERSION:' .github/workflows/new-tests.yml | sed 's/.*CLITEST_VERSION: "=\([^"]*\)"/\1/')
@@ -15,7 +18,7 @@ clitest *ARGS:
   ARGS="{{ARGS}}"
   if [ -z "$ARGS" ]; then
     echo "Running all tests..."
-    echo " 🔎 Re-run with `just clitest <test1> <test2>` to see detailed output."
+    echo ' 🔎 Re-run with `just clitest <test1> <test2>` to see detailed output.'
     find tests/scripts -name "*.cli" -type f | while read -r test_file; do
       test_name=$(basename "$test_file" .cli)
       PATH=$DEBUG_TARGET:$PATH clitest --quiet --timeout 120 "$test_file"

--- a/justfile
+++ b/justfile
@@ -1,0 +1,29 @@
+test: cargo-test clitest
+
+cargo-test:
+  cargo test
+
+# `just clitest` runs all tests, in quiet mode.
+# `just clitest <test1> <test2>` runs only the specified tests, in verbose mode.
+clitest *ARGS:
+  #!/bin/bash
+  set -euf -o pipefail
+  CLITEST_VERSION=$(grep 'CLITEST_VERSION:' .github/workflows/new-tests.yml | sed 's/.*CLITEST_VERSION: "=\([^"]*\)"/\1/')
+  cargo install clitest@$CLITEST_VERSION
+  DEBUG_TARGET=`pwd`/target/debug/
+
+  ARGS="{{ARGS}}"
+  if [ -z "$ARGS" ]; then
+    echo "Running all tests..."
+    echo " 🔎 Re-run with `just clitest <test1> <test2>` to see detailed output."
+    find tests/scripts -name "*.cli" -type f | while read -r test_file; do
+      test_name=$(basename "$test_file" .cli)
+      PATH=$DEBUG_TARGET:$PATH clitest --quiet --timeout 120 "$test_file"
+    done
+  else
+    echo "Running tests: $ARGS"
+    for test_file in $ARGS; do
+      test_name=$(basename "$test_file" .cli)
+      PATH=$DEBUG_TARGET:$PATH clitest --timeout 120 "$test_file"
+    done
+  fi

--- a/tests/scripts/migrations/extract.cli
+++ b/tests/scripts/migrations/extract.cli
@@ -16,6 +16,13 @@ $ gel instance create -I $INSTANCE
 %EXIT any
 *
 
+# Log the instance logs in the background to help debug failures
+background {
+    $ gel instance logs --tail 10 --follow -I $INSTANCE
+    %EXIT any
+    *
+}
+
 $ gel branch drop $BRANCH --force --non-interactive
 %EXIT any
 *

--- a/tests/scripts/migrations/input_required.cli
+++ b/tests/scripts/migrations/input_required.cli
@@ -23,6 +23,13 @@ $ gel instance create -I $INSTANCE
 %EXIT any
 *
 
+# Log the instance logs in the background to help debug failures
+background {
+    $ gel instance logs --tail 10 --follow -I $INSTANCE
+    %EXIT any
+    *
+}
+
 $ gel branch drop $BRANCH --force --non-interactive
 %EXIT any
 *


### PR DESCRIPTION
Bump clitest and add a `justfile` so we can run CLI tests more easily.

```
just clitest # run all tests
just clitest tests/scripts/project/watch.cli # run a single test
```