### PR TITLE
Fix incremental backups after a restore to an older point

### DIFF
--- a/gel-cli-instance/src/local/localbackup.rs
+++ b/gel-cli-instance/src/local/localbackup.rs
@@ -403,7 +403,7 @@ impl InstanceBackup for LocalBackup {
                         if has_wal_line {
                             log::warn!("This may be expected if the database was restored to an old backup.");
                         } else {
-                            log::warn!("Please report this error to the Gel team:");
+                            log::warn!("Please report this error at https://github.com/geldata/gel-cli:");
                             for line in error.lines() {
                                 log::warn!("  {}", line);
                             }

--- a/tests/scripts/backup/backup.cli
+++ b/tests/scripts/backup/backup.cli
@@ -9,67 +9,93 @@ ignore {
     ! Connecting to Gel instance '%{DATA}' at %{HOSTPORT}...
 }
 
+set INSTANCE "backup-test";
+
 if TARGET_OS != "windows" {
-    $ gel instance destroy -I inst1 --force
+    $ gel instance destroy -I $INSTANCE --force
     %EXIT any
     *
 
-    $ gel instance create -I inst1
+    $ gel instance create -I $INSTANCE
     *
 
-    $ gel instance list-backups -I inst1
+    defer {
+        $ gel instance destroy -I $INSTANCE --force
+        %EXIT any
+        *
+    }
+
+    set GEL_INSTANCE $INSTANCE;
+
+    $ gel instance list-backups
     ! No backups found.
 
-    $ gel -I inst1 query "CREATE TYPE SpaceFiller { CREATE PROPERTY name: str };"
+    $ gel query "CREATE TYPE SpaceFiller { CREATE PROPERTY name: str };"
     ! OK: CREATE TYPE
 
-    $ gel -I inst1 query "for i in range_unpack(range(0,1000)) union ( insert SpaceFiller { name := str_repeat(<str>i, 1000000) } );" > /dev/null
+    $ gel query "for i in range_unpack(range(0,10)) union ( insert SpaceFiller { name := str_repeat(<str>i, 1000000) } );" > /dev/null
     
-    $ gel instance backup -I inst1 --non-interactive
+    $ gel instance backup --non-interactive
     *
-    ! Successfully created a backup %{UUID} for Gel instance 'inst1'
+    ! Successfully created a backup %{UUID} for Gel instance '%{DATA}'
 
-    # Ensure that stopping an instance doesn't cause the next backup to fail.
-    $ gel instance stop -I inst1
+    $ gel instance backup --non-interactive
     *
+    ! Successfully created a backup %{UUID} for Gel instance '%{DATA}'
 
-    # Damage the WAL
-    $ rm ~/.local/share/edgedb/data/inst1/pg_wal/*
-
-    $ gel instance start -I inst1
-    *
-
-    $ gel instance backup -I inst1 --non-interactive
-    *
-    ! Successfully created a backup %{UUID} for Gel instance 'inst1'
-
-    $ gel -I inst1 query "CREATE TYPE user { CREATE PROPERTY name: str };"
+    $ gel query "CREATE TYPE user { CREATE PROPERTY name: str };"
     ! OK: CREATE TYPE
 
-    $ gel -I inst1 query 'INSERT user { name := "John" };'
+    $ gel query 'INSERT user { name := "John" };'
     ! {"id": "%{UUID}"}
 
-    $ gel instance backup -I inst1 --non-interactive
+    $ gel instance backup --non-interactive
     *
-    ! Successfully created a backup %{UUID} for Gel instance 'inst1'
+    ! Successfully created a backup %{UUID} for Gel instance '%{DATA}'
 
-    $ gel instance list-backups -I inst1
+    $ gel instance list-backups
     *
 
-    $ gel -I inst1 query 'INSERT user { name := "Mary" };'
+    $ gel query 'INSERT user { name := "Mary" };'
     ! {"id": "%{UUID}"}
 
-    $ gel -I inst1 query 'INSERT user { name := "Alice" };'
+    $ gel query 'INSERT user { name := "Alice" };'
     ! {"id": "%{UUID}"}
 
-    $ gel -I inst1 query 'SELECT user { name } ORDER BY .name;'
+    $ gel query 'SELECT user { name } ORDER BY .name;'
     ! {"name": "Alice"}
     ! {"name": "John"}
     ! {"name": "Mary"}
 
-    $ gel instance restore -I inst1 --non-interactive --latest
+    $ gel instance list-backups --json 2>/dev/null | jq -r '.[] | .id' | tail -n 1
+    %SET PREVIOUS_BACKUP_ID
+    ! %{UUID}
+
+    # Take a backup but we're going to restore between here and the next backup.
+    $ gel instance backup --non-interactive
     *
 
-    $ gel -I inst1 query 'SELECT user { name } ORDER BY .name;'
+    $ gel instance restore --non-interactive --backup-id $PREVIOUS_BACKUP_ID
+    *
+
+    $ gel query 'SELECT user { name } ORDER BY .name;'
     ! {"name": "John"}
+
+    $ gel query "for i in range_unpack(range(0,10)) union ( insert SpaceFiller { name := str_repeat(<str>i, 1000000) } );" > /dev/null
+
+    # Make sure we can fall back to a full backup
+    $ gel instance backup --non-interactive
+    *
+    ! %{GREEDYDATA} Incremental backup failed, falling back to full backup...
+    ! %{GREEDYDATA} This may be expected if the database was restored to an old backup.
+    ! Successfully created a backup %{UUID} for Gel instance '%{DATA}'
+
+    $ gel instance list-backups
+    *
+    ! │ %{UUID} │ %{DATA} │ Manual               │ %{GREEDYDATA} │
+    ! │ %{UUID} │ %{DATA} │ Manual (Incremental) │ %{GREEDYDATA} │
+    ! │ %{UUID} │ %{DATA} │ Manual (Incremental) │ %{GREEDYDATA} │
+    ! │ %{UUID} │ %{DATA} │ Manual (Incremental) │ %{GREEDYDATA} │
+    ! │ %{UUID} │ %{DATA} │ Manual               │ %{GREEDYDATA} │
+    *
 }

--- a/tests/scripts/backup/backup.cli
+++ b/tests/scripts/backup/backup.cli
@@ -20,6 +20,25 @@ if TARGET_OS != "windows" {
     $ gel instance list-backups -I inst1
     ! No backups found.
 
+    $ gel -I inst1 query "CREATE TYPE SpaceFiller { CREATE PROPERTY name: str };"
+    ! OK: CREATE TYPE
+
+    $ gel -I inst1 query "for i in range_unpack(range(0,1000)) union ( insert SpaceFiller { name := str_repeat(<str>i, 1000000) } );" > /dev/null
+    
+    $ gel instance backup -I inst1 --non-interactive
+    *
+    ! Successfully created a backup %{UUID} for Gel instance 'inst1'
+
+    # Ensure that stopping an instance doesn't cause the next backup to fail.
+    $ gel instance stop -I inst1
+    *
+
+    # Damage the WAL
+    $ rm ~/.local/share/edgedb/data/inst1/pg_wal/*
+
+    $ gel instance start -I inst1
+    *
+
     $ gel instance backup -I inst1 --non-interactive
     *
     ! Successfully created a backup %{UUID} for Gel instance 'inst1'


### PR DESCRIPTION
We failed to fall back to incremental backups if you restored to something that wasn't `--latest`, which created an alternate postgres timeline and caused the incremental backup process to fail.