### PR TITLE
Fix instance name resolution

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -134,8 +134,3 @@ pub async fn has_docker() -> bool {
     }
     false
 }
-
-#[tokio::main]
-pub async fn has_docker_blocking() -> bool {
-    has_docker().await
-}

--- a/src/instance/backup.rs
+++ b/src/instance/backup.rs
@@ -138,7 +138,7 @@ pub async fn list(cmd: &ListBackups, opts: &crate::options::Options) -> anyhow::
         bail!("Instance backup/restore is not yet supported on Windows");
     }
 
-    let inst_name = cmd.instance_opts.instance()?;
+    let inst_name = cmd.instance_opts.instance().await?;
     let _lock = LockManager::lock_read_instance_async(&inst_name).await?;
     let instance = get_instance(opts, &inst_name)?.backup()?;
     let backups = instance.list_backups().await?;
@@ -186,7 +186,7 @@ pub async fn backup(cmd: &Backup, opts: &crate::options::Options) -> anyhow::Res
         bail!("Instance backup/restore is not yet supported on Windows");
     }
 
-    let inst_name = cmd.instance_opts.instance()?;
+    let inst_name = cmd.instance_opts.instance().await?;
     let _lock = LockManager::lock_read_instance_async(&inst_name).await?;
     let backup = get_instance(opts, &inst_name)?.backup()?;
 
@@ -243,7 +243,7 @@ pub async fn restore(cmd: &Restore, opts: &crate::options::Options) -> anyhow::R
         bail!("Instance backup/restore is not yet supported on Windows");
     }
 
-    let inst_name = cmd.instance_opts.instance()?;
+    let inst_name = cmd.instance_opts.instance().await?;
     let _lock = LockManager::lock_instance_async(&inst_name).await?;
     let backup = get_instance(opts, &inst_name)?.backup()?;
 

--- a/src/instance/control.rs
+++ b/src/instance/control.rs
@@ -476,8 +476,9 @@ pub fn do_stop(name: &str) -> anyhow::Result<()> {
     }
 }
 
-pub fn stop(options: &Stop) -> anyhow::Result<()> {
-    let name = match options.instance_opts.instance()? {
+#[tokio::main(flavor = "current_thread")]
+pub async fn stop(options: &Stop) -> anyhow::Result<()> {
+    let name = match options.instance_opts.instance().await? {
         InstanceName::Local(name) => {
             if cfg!(windows) {
                 return windows::stop(options, &name);
@@ -586,8 +587,9 @@ pub fn do_restart(inst: &InstanceInfo) -> anyhow::Result<()> {
     }
 }
 
-pub fn restart(cmd: &Restart, options: &crate::Options) -> anyhow::Result<()> {
-    match cmd.instance_opts.instance()? {
+#[tokio::main(flavor = "current_thread")]
+pub async fn restart(cmd: &Restart, options: &crate::Options) -> anyhow::Result<()> {
+    match cmd.instance_opts.instance().await? {
         InstanceName::Local(name) => {
             let meta = InstanceInfo::read(&name)?;
             do_restart(&meta)

--- a/src/portable/extension.rs
+++ b/src/portable/extension.rs
@@ -156,8 +156,9 @@ fn list(_: &ExtensionList, options: &Options) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-fn uninstall(cmd: &ExtensionUninstall, _options: &Options) -> Result<(), anyhow::Error> {
-    let inst = get_local_instance(cmd.instance_opts.instance()?)?;
+#[tokio::main(flavor = "current_thread")]
+async fn uninstall(cmd: &ExtensionUninstall, _options: &Options) -> Result<(), anyhow::Error> {
+    let inst = get_local_instance(cmd.instance_opts.instance().await?)?;
 
     if cfg!(windows) {
         return windows::extension_uninstall(cmd);
@@ -171,8 +172,9 @@ fn uninstall(cmd: &ExtensionUninstall, _options: &Options) -> Result<(), anyhow:
     Ok(())
 }
 
-fn install(cmd: &ExtensionInstall, _options: &Options) -> Result<(), anyhow::Error> {
-    let inst = get_local_instance(cmd.instance_opts.instance()?)?;
+#[tokio::main(flavor = "current_thread")]
+async fn install(cmd: &ExtensionInstall, _options: &Options) -> Result<(), anyhow::Error> {
+    let inst = get_local_instance(cmd.instance_opts.instance().await?)?;
 
     if cfg!(windows) {
         return windows::extension_install(cmd);
@@ -262,12 +264,16 @@ fn run_extension_loader(
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
-fn list_available(list: &ExtensionListAvailable, _options: &Options) -> Result<(), anyhow::Error> {
-    let inst = get_local_instance(list.instance_opts.instance()?)?;
+#[tokio::main(flavor = "current_thread")]
+async fn list_available(
+    cmd: &ExtensionListAvailable,
+    _options: &Options,
+) -> Result<(), anyhow::Error> {
+    let inst = get_local_instance(cmd.instance_opts.instance().await?)?;
 
     let version = inst.get_version()?.specific();
-    let channel = list.channel.unwrap_or(Channel::Stable);
-    let slot = list.slot.clone().unwrap_or(version.extension_server_slot());
+    let channel = cmd.channel.unwrap_or(Channel::Stable);
+    let slot = cmd.slot.clone().unwrap_or(version.extension_server_slot());
     debug!("Instance: {version} {channel:?} {slot}");
     let packages = get_platform_extension_packages(channel, &slot, get_server()?)?;
 

--- a/tests/scripts/backup/backup.cli
+++ b/tests/scripts/backup/backup.cli
@@ -16,6 +16,10 @@ if TARGET_OS != "windows" {
     %EXIT any
     *
 
+    $ gel instance list-backups
+    %EXIT 2
+    ! gel error: Instance name argument is required, use '-I name'
+
     $ gel instance create -I $INSTANCE
     *
 
@@ -34,7 +38,7 @@ if TARGET_OS != "windows" {
     ! OK: CREATE TYPE
 
     $ gel query "for i in range_unpack(range(0,10)) union ( insert SpaceFiller { name := str_repeat(<str>i, 1000000) } );" > /dev/null
-    
+
     $ gel instance backup --non-interactive
     *
     ! Successfully created a backup %{UUID} for Gel instance '%{DATA}'


### PR DESCRIPTION
It was calling out to `has_docker`, which was spawning a tokio runtime.
This worked fine, unless it was called from an existing runtime.
Which happened in `gel instance backup` (without --instance),
resulting in a panic.
