### PR TITLE
Fix uv project detection for dynamic versions

### DIFF
--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -205,9 +205,8 @@ define_env! {
     #[env(GEL_AUTO_BACKUP_MODE)]
     auto_backup_mode: AutoBackupMode,
 
-    /// How we should invoke via `uv run` (or not)
+    /// How we should detect uv project
     #[env(GEL_GENERATE_USE_UV)]
-    #[setenv=0]
     use_uv: UseUv,
 }
 


### PR DESCRIPTION
`uv version` doesn't work with dynamic version (astral-sh/uv#14137) yet, while there's no simple way to discover uv project (astral-sh/uv#13636), so let's just parse ~the `uv run -v` debug log first, and fallback to `uv version` if the debug log format changes someday.~ the `uv version -v` debug log.

~Also added `--no-sync` flag to `uv run` calls, so that they would deal the minimal changes to the project dir. Unfortunately, `.venv` would still get created if it doesn't exist yet, even with the `--no-sync` flag.~