### PR TITLE
Make backup run without prompt, always

### DIFF
--- a/src/instance/backup.rs
+++ b/src/instance/backup.rs
@@ -66,10 +66,6 @@ pub struct Backup {
 
     #[command(flatten)]
     pub instance_opts: InstanceOptions,
-
-    /// Do not ask questions.
-    #[arg(long)]
-    pub non_interactive: bool,
 }
 
 #[derive(clap::Args, IntoArgs, Clone, Debug)]
@@ -189,15 +185,6 @@ pub async fn backup(cmd: &Backup, opts: &crate::options::Options) -> anyhow::Res
     let inst_name = cmd.instance_opts.instance().await?;
     let _lock = LockManager::lock_read_instance_async(&inst_name).await?;
     let backup = get_instance(opts, &inst_name)?.backup()?;
-
-    let prompt = format!(
-        "Will create a backup for {inst_name:#}.\
-        \n\nContinue?",
-    );
-
-    if !cmd.non_interactive && !question::Confirm::new(prompt).ask()? {
-        return Ok(());
-    }
 
     let progress_bar = ProgressBar::default();
 

--- a/tests/scripts/backup/backup.cli
+++ b/tests/scripts/backup/backup.cli
@@ -39,11 +39,11 @@ if TARGET_OS != "windows" {
 
     $ gel query "for i in range_unpack(range(0,10)) union ( insert SpaceFiller { name := str_repeat(<str>i, 1000000) } );" > /dev/null
 
-    $ gel instance backup --non-interactive
+    $ gel instance backup
     *
     ! Successfully created a backup %{UUID} for Gel instance '%{DATA}'
 
-    $ gel instance backup --non-interactive
+    $ gel instance backup
     *
     ! Successfully created a backup %{UUID} for Gel instance '%{DATA}'
 
@@ -53,7 +53,7 @@ if TARGET_OS != "windows" {
     $ gel query 'INSERT user { name := "John" };'
     ! {"id": "%{UUID}"}
 
-    $ gel instance backup --non-interactive
+    $ gel instance backup
     *
     ! Successfully created a backup %{UUID} for Gel instance '%{DATA}'
 
@@ -76,7 +76,7 @@ if TARGET_OS != "windows" {
     ! %{UUID}
 
     # Take a backup but we're going to restore between here and the next backup.
-    $ gel instance backup --non-interactive
+    $ gel instance backup
     *
 
     $ gel instance restore --non-interactive --backup-id $PREVIOUS_BACKUP_ID
@@ -88,7 +88,7 @@ if TARGET_OS != "windows" {
     $ gel query "for i in range_unpack(range(0,10)) union ( insert SpaceFiller { name := str_repeat(<str>i, 1000000) } );" > /dev/null
 
     # Make sure we can fall back to a full backup
-    $ gel instance backup --non-interactive
+    $ gel instance backup
     *
     ! %{GREEDYDATA} Incremental backup failed, falling back to full backup...
     ! %{GREEDYDATA} This may be expected if the database was restored to an old backup.

--- a/tests/scripts/upgrade.cli
+++ b/tests/scripts/upgrade.cli
@@ -41,7 +41,7 @@ choice {
 !   gel -I inst3
 
 if TARGET_OS != "windows" {
-    $ gel instance backup --instance=inst3 --non-interactive
+    $ gel instance backup --instance=inst3
     ? Successfully created a backup [a-z0-9-]+ for Gel instance 'inst3'
 }
 


### PR DESCRIPTION
There's no need to prompt for a backup -- it's not destructive.