### PR TITLE
Limit the versions we return in list-versions

### DIFF
--- a/src/portable/ver.rs
+++ b/src/portable/ver.rs
@@ -264,6 +264,20 @@ impl Filter {
         }
     }
 
+    /// If minor is not specified, match only on major, otherwise use specific
+    /// match
+    pub fn matches_loose(&self, spec: &Specific) -> bool {
+        if self.exact {
+            self.matches_exact(spec)
+        } else {
+            if self.minor.is_none() {
+                spec.major == self.major
+            } else {
+                self.matches_specific(spec)
+            }
+        }
+    }
+
     pub fn matches_specific(&self, spec: &Specific) -> bool {
         use FilterMinor as Q;
         use MinorVersion as M;

--- a/tests/scripts/server/list_versions.cli
+++ b/tests/scripts/server/list_versions.cli
@@ -1,0 +1,29 @@
+#!/usr/bin/env clitest --v0
+ignore {
+    ! Newer version of gel tool exists %{GREEDYDATA}
+}
+
+$ gel server list-versions
+reject {
+    ! testing
+    ! nightly
+}
+! Listing %{DATA}current, stable channel%{DATA} versions of %{DATA}Gel%{DATA}:
+*
+
+$ gel server list-versions --installed-only
+! Listing %{DATA}installed%{DATA} versions of %{DATA}Gel%{DATA}:
+*
+
+$ gel server list-versions --installed-only --channel=stable
+! Listing %{DATA}installed, stable channel%{DATA} versions of %{DATA}Gel%{DATA}:
+*
+
+$ gel server list-versions --channel=nightly
+! Listing %{DATA}nightly channel%{DATA} versions of %{DATA}Gel%{DATA}:
+*
+
+$ gel server list-versions --version=1.0
+! Listing %{DATA}matching, stable channel%{DATA} versions of %{DATA}Gel%{DATA}:
+*
+


### PR DESCRIPTION
`gel server list-versions` is pretty noisy, so let's filter to showing just the latest stable for now and give users the ability to change the channel as needed.