### PR TITLE
Fix list-backups breaking in-process backups

### DIFF
--- a/gel-cli-instance/Cargo.toml
+++ b/gel-cli-instance/Cargo.toml
@@ -30,3 +30,6 @@ dunce = "1.0.5"
 [dev-dependencies]
 rstest = "0.25"
 tokio = { version = "1", features = ["full"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(slowdown)'] }


### PR DESCRIPTION
Fixes #1716

We were failing to parse UUIDs of in-progress backups which have a . prefix and .tmp suffix.