### PR TITLE
gel migrate create --explicit

### DIFF
--- a/src/migrations/create.rs
+++ b/src/migrations/create.rs
@@ -65,6 +65,10 @@ pub struct Command {
     /// This safe default can be overridden with `--allow-unsafe`.
     #[arg(long)]
     pub non_interactive: bool,
+    /// Run the migration creation in explicit mode. In this mode, the user
+    /// will receive more detailed prompts.
+    #[arg(long)]
+    pub explicit: bool,
     /// Apply the most probable unsafe changes in case there are ones. This
     /// is only useful in non-interactive mode.
     #[arg(long)]
@@ -142,7 +146,7 @@ pub enum SourceName {
     File(PathBuf),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 enum Choice {
     Yes,
     No,
@@ -219,6 +223,7 @@ struct InteractiveMigration<'a> {
     save_point: usize,
     operations: Vec<Set<String>>,
     confirmed: Vec<String>,
+    explicit: bool,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -313,42 +318,47 @@ fn print_statements(statements: impl IntoIterator<Item = impl AsRef<str>>) {
     }
 }
 
-async fn choice(prompt: &str) -> anyhow::Result<Choice> {
+async fn choice(explicit: bool, prompt: &str) -> anyhow::Result<Choice> {
     use Choice::*;
 
+    let choices: &[_] = if explicit {&[
+        (Yes, &["y", "yes"], r#"Confirm the prompt"#),
+        (No, &["n", "no"], "Reject the prompt; server will attempt to generate another suggestion"),
+        (Confirmed, &["c", "confirmed"], "List already confirmed EdgeQL statements for the current migration"),
+        (Back, &["b", "back"], "Go back a step by reverting latest accepted statements"),
+        (Split, &["s", "stop"], "Stop and finalize migration with only current accepted changes"),
+        (Quit, &["q", "quit"], "Quit without saving changes"),
+    ]} else {&[
+        (Yes, &["y", "yes"], r#"Confirm the prompt ("l" to see suggested statements)"#),
+        (No, &["n", "no"], "Reject the prompt; server will attempt to generate another suggestion"),
+        (List, &["l", "list"], "List proposed DDL statements for the current prompt"),
+        (Confirmed, &["c", "confirmed"], "List already confirmed EdgeQL statements for the current migration"),
+        (Back, &["b", "back"], "Go back a step by reverting latest accepted statements"),
+        (Split, &["s", "stop"], "Stop and finalize migration with only current accepted changes"),
+        (Quit, &["q", "quit"], "Quit without saving changes"),
+    ]};
+
+    if explicit {
+        println!("Select an action:");
+        println!();
+        for (_, input, help) in choices {
+            println!("{:?} (or {:?}): {help}", input[1], input[0]);
+        }
+        println!();
+    }
+
     let mut q = question::Choice::new(prompt.to_string());
-    q.option(
-        Yes,
-        &["y", "yes"],
-        r#"Confirm the prompt ("l" to see suggested statements)"#,
-    );
-    q.option(
-        No,
-        &["n", "no"],
-        "Reject the prompt; server will attempt to generate another suggestion",
-    );
-    q.option(
-        List,
-        &["l", "list"],
-        "List proposed DDL statements for the current prompt",
-    );
-    q.option(
-        Confirmed,
-        &["c", "confirmed"],
-        "List already confirmed EdgeQL statements for the current migration",
-    );
-    q.option(
-        Back,
-        &["b", "back"],
-        "Go back a step by reverting latest accepted statements",
-    );
-    q.option(
-        Split,
-        &["s", "stop"],
-        "Stop and finalize migration with only current accepted changes",
-    );
-    q.option(Quit, &["q", "quit"], "Quit without saving changes");
-    q.async_ask().await
+    for (choice, input, help) in choices {
+        q.option(choice, input.as_slice(), *help);
+    }
+
+    let res = *q.async_ask().await?;
+
+    if explicit {
+        println!();
+    }
+
+    Ok(res)
 }
 
 #[context("could not read schema in {}", ctx.schema_dir.display())]
@@ -626,6 +636,7 @@ impl InteractiveMigration<'_> {
             save_point: 0,
             operations: vec![Set::new()],
             confirmed: Vec::new(),
+            explicit: false,
         }
     }
     async fn save_point(&mut self) -> Result<(), Error> {
@@ -645,6 +656,7 @@ impl InteractiveMigration<'_> {
         .await
     }
     async fn run(mut self, options: &Command) -> anyhow::Result<CurrentMigration> {
+        self.explicit = options.explicit;
         self.save_point().await?;
         loop {
             let descr =
@@ -691,7 +703,7 @@ impl InteractiveMigration<'_> {
                 println!("(approved as part of an earlier prompt)");
                 let input = self
                     .cli
-                    .ping_while(get_user_input(&proposal.required_user_input))
+                    .ping_while(get_user_input(self.explicit, &proposal.required_user_input))
                     .await;
                 match input {
                     Ok(data) => break data,
@@ -711,11 +723,25 @@ impl InteractiveMigration<'_> {
                 "Apply the DDL statements?"
             };
             loop {
-                match self.cli.ping_while(choice(prompt)).await? {
+                let choice = if self.explicit {
+                    println!("{prompt}");
+                    println!();
+                    if self.explicit {
+                        println!("If so, the following DDL statements will be applied:");
+                        println!();
+                        print_statements(proposal.statements.iter().map(|s| &s.text));
+                        println!();
+                    }
+                    self.cli.ping_while(choice(self.explicit, "Which action do you want to take?")).await?
+                } else {
+                    self.cli.ping_while(choice(self.explicit, prompt)).await?
+                };
+
+                match choice {
                     Yes => {
                         let input_res = self
                             .cli
-                            .ping_while(get_user_input(&proposal.required_user_input))
+                            .ping_while(get_user_input(self.explicit,&proposal.required_user_input))
                             .await;
                         match input_res {
                             Ok(data) => input = data,
@@ -978,13 +1004,48 @@ fn get_input(req: &RequiredUserInput) -> Result<String, anyhow::Error> {
     }
 }
 
+fn get_input_explicit(req: &RequiredUserInput) -> Result<String, anyhow::Error> {
+    let prompt = "Conversion expression:";
+    let mut prev = make_default_expression(req).unwrap_or_default();
+    loop {
+        println!("{}.", req.prompt);
+        println!("If left blank, the migration will use the expression:");
+        println!("{prev}");
+        println!();
+
+        let mut value = match prompt::expression(&prompt, &req.placeholder, &prev) {
+            Ok(val) => val,
+            Err(e) => match e.downcast::<ReadlineError>() {
+                Ok(ReadlineError::Eof) => return Err(Refused.into()),
+                Ok(e) => return Err(e.into()),
+                Err(e) => return Err(e),
+            },
+        };
+        match expr::check(&value) {
+            Ok(()) => {}
+            Err(e) => {
+                println!("Invalid expression: {e}");
+                prev = value;
+                continue;
+            }
+        }
+        add_newline_after_comment(&mut value)?;
+        return Ok(value);
+    }
+}
+
 async fn get_user_input(
+    explicit: bool,
     req: &[RequiredUserInput],
 ) -> Result<BTreeMap<String, String>, anyhow::Error> {
     let mut result = BTreeMap::new();
     for item in req {
         let copy = item.clone();
-        let input = unblock(move || get_input(&copy)).await??;
+        let input = if explicit {
+            unblock(move || get_input_explicit(&copy)).await??
+        } else {
+            unblock(move || get_input(&copy)).await??
+        };
         result.insert(item.placeholder.clone(), input);
     }
     Ok(result)

--- a/src/migrations/prompt.rs
+++ b/src/migrations/prompt.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::io::IsTerminal;
 
 use anyhow::Context as _;
 use edgeql_parser::expr;
@@ -66,6 +67,21 @@ pub fn expression(
     history_name: &str,
     default: &str,
 ) -> Result<String, anyhow::Error> {
+    use std::io::Write;
+
+    if !std::io::stdin().is_terminal() {
+        print!("{}", prompt);
+        _ = std::io::stdout().flush();
+        let mut buf = String::new();
+        std::io::stdin().read_line(&mut buf)?;
+        if buf.is_empty() {
+            println!("{default}");
+            return Ok(default.to_string());
+        }
+        println!();
+        return Ok(buf);
+    }
+
     let history_name = format!("migr_{}", &history_name);
     let config = Config::builder();
     let config = config.edit_mode(EditMode::Emacs);

--- a/src/project/sync.rs
+++ b/src/project/sync.rs
@@ -145,6 +145,7 @@ async fn sync(
             debug_print_queries: false,
             debug_print_err: false,
             quiet: true,
+            explicit: false,
         },
         &mut conn,
     )

--- a/tests/scripts/migrations/input_required.cli
+++ b/tests/scripts/migrations/input_required.cli
@@ -68,6 +68,7 @@ $ gel migration create --non-interactive
 $ printf "yes\n.foo[IS default::Child2]\n" | gel migration create
 ! did you alter the type of link 'foo' of object type 'default::Base'? [y,n,l,c,b,s,q,?]
 ! Please specify a conversion expression to alter the type of link 'foo':
+! cast_expr> 
 ! Created %{DATA}, id: %{DATA}
 
 $ cat dbschema/migrations/00002-*.edgeql
@@ -85,9 +86,61 @@ $ rm dbschema/migrations/00002-*.edgeql
 *
 
 # Adding a comment to input doesn't affect result
-$ printf "yes\n.foo[IS default::Child2] # comment\n" | gel migration create
+$ printf "list\nyes\n.foo[IS default::Child2] # comment\n" | gel migration create
+! did you alter the type of link 'foo' of object type 'default::Base'? [y,n,l,c,b,s,q,?]
+! The following DDL statements will be applied:
+!     ALTER TYPE default::Base {
+!         ALTER LINK foo {
+!             SET TYPE default::Child2 USING (\(cast_expr));
+!         };
+!     };
 ! did you alter the type of link 'foo' of object type 'default::Base'? [y,n,l,c,b,s,q,?]
 ! Please specify a conversion expression to alter the type of link 'foo':
+! cast_expr> 
+! Created %{DATA}, id: %{DATA}
+
+$ cat dbschema/migrations/00002-*.edgeql
+! CREATE MIGRATION %{DATA}
+!     ONTO m1d6kfhjnqmrw4lleqvx6fibf5hpmndpw2tn2f6o4wm6fjyf55dhcq
+! {
+!   ALTER TYPE default::Base {
+!       ALTER LINK foo {
+!           SET TYPE default::Child2 USING (.foo[IS default::Child2]);
+!       };
+!   };
+! };
+
+$ rm dbschema/migrations/00002-*.edgeql
+*
+
+# Explicit migration mode
+$ printf "yes\n.foo[IS default::Child2] # comment\n" | gel migration create --explicit
+! did you alter the type of link 'foo' of object type 'default::Base'?
+!
+! If so, the following DDL statements will be applied:
+!
+!     ALTER TYPE default::Base {
+!         ALTER LINK foo {
+!             SET TYPE default::Child2 USING (\(cast_expr));
+!         };
+!     };
+!
+! Select an action:
+!
+! "yes" (or "y"): Confirm the prompt
+! "no" (or "n"): Reject the prompt; server will attempt to generate another suggestion
+! "confirmed" (or "c"): List already confirmed EdgeQL statements for the current migration
+! "back" (or "b"): Go back a step by reverting latest accepted statements
+! "stop" (or "s"): Stop and finalize migration with only current accepted changes
+! "quit" (or "q"): Quit without saving changes
+!
+! Which action do you want to take? [y,n,c,b,s,q,?]
+!
+! Please specify a conversion expression to alter the type of link 'foo'.
+! If left blank, the migration will use the expression:
+! .foo[IS default::Child2]
+!
+! Conversion expression:
 ! Created %{DATA}, id: %{DATA}
 
 $ cat dbschema/migrations/00002-*.edgeql


### PR DESCRIPTION
Implements a more verbose, much more explicit form of gel migrate create. We could consider making this the default and adding a `--compact` version.

```
did you alter the type of link 'foo' of object type 'default::Base'?

If so, the following DDL statements will be applied:

    ALTER TYPE default::Base {
        ALTER LINK foo {
            SET TYPE default::Child2 USING (\(cast_expr));
        };
    };

Select an action:

"yes" (or "y"): Confirm the prompt
"no" (or "n"): Reject the prompt; server will attempt to generate another suggestion
"confirmed" (or "c"): List already confirmed EdgeQL statements for the current migration
"back" (or "b"): Go back a step by reverting latest accepted statements
"stop" (or "s"): Stop and finalize migration with only current accepted changes
"quit" (or "q"): Quit without saving changes

Which action do you want to take? [y,n,c,b,s,q,?]

Please specify a conversion expression to alter the type of link 'foo'.
If left blank, the migration will use the expression:
.foo[IS default::Child2]

Conversion expression: .foo[IS default::Child2]
Created migration ...
```
