### PR TITLE
Tweak the rules for in-place upgrades

### DIFF
--- a/src/project/upgrade.rs
+++ b/src/project/upgrade.rs
@@ -342,9 +342,9 @@ fn upgrade_local(
 
                 let compatible_pg = true;
                 let compatible_in_place = compatible_pg
-                    && inst_ver.major >= 6
-                    && pkg_ver.major >= 6
-                    && inst_ver.major != pkg_ver.major;
+                    && instance::upgrade::is_in_place_upgrade_compatible(&inst_ver, &pkg_ver);
+                let default_in_place =
+                    instance::upgrade::is_in_place_upgrade_default(&inst_ver, &pkg_ver);
 
                 if cmd.force_in_place && !compatible_in_place {
                     return Err(anyhow::anyhow!(
@@ -354,9 +354,7 @@ fn upgrade_local(
                     .into());
                 }
 
-                if (compatible_in_place || cmd.force_in_place)
-                    && !cmd.force
-                    && !cmd.force_dump_restore
+                if (default_in_place || cmd.force_in_place) && !cmd.force && !cmd.force_dump_restore
                 {
                     upgrade::upgrade_in_place(inst, inst_ver.clone(), pkg)?;
                 } else {

--- a/tests/scripts/upgrade.cli
+++ b/tests/scripts/upgrade.cli
@@ -27,7 +27,7 @@ if TARGET_OS != "windows" {
 }
 
 # Upgrade to nightly, in-place
-$ gel instance upgrade --instance=inst3 --to-nightly
+$ gel instance upgrade --instance=inst3 --to-nightly --force-in-place
 %TIMEOUT 120s
 ? Upgrading from %{VERSION} to version %{VERSION}, in-place
 *


### PR DESCRIPTION
Disable doing an IPU to 6.0-beta.1, because it has some bad brokenness
with the auth extension.

Also, only default to IPUs for RCs and release versions, not for other
pre-releases.

Maybe we should never default to it yet?