### PR TITLE
Use backticks for help text interpolation

### DIFF
--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -23,15 +23,15 @@ use crate::project;
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct Command {
-    /// Runs "{BRANDING_CLI_CMD} migration apply --dev-mode" on changes to schema definitions.
+    /// Runs "`BRANDING_CLI_CMD` migration apply --dev-mode" on changes to schema definitions.
     ///
-    /// This runs in addition to scripts in {MANIFEST_FILE_DISPLAY_NAME}.
+    /// This runs in addition to scripts in `MANIFEST_FILE_DISPLAY_NAME`.
     #[arg(short = 'm', long)]
     pub migrate: bool,
 
-    /// Runs "{BRANDING_CLI_CMD} sync" on changes to gel.local.toml.
+    /// Runs "`BRANDING_CLI_CMD` sync" on changes to gel.local.toml.
     ///
-    /// This runs in addition to scripts in {MANIFEST_FILE_DISPLAY_NAME}.
+    /// This runs in addition to scripts in `MANIFEST_FILE_DISPLAY_NAME`.
     #[arg(short = 's', long)]
     pub sync: bool,
 


### PR DESCRIPTION
These were showing up as literal `{SOME_TEXT}` in the printed help string. I looked at some of the other help text and noticed that it uses backticks for this, so updated these few and did a quick grep around and didn't find any others.