### PR TITLE
DX: fix interactive migration create

### DIFF
--- a/tests/scripts/migrations/input_required.cli
+++ b/tests/scripts/migrations/input_required.cli
@@ -143,10 +143,11 @@ $ printf "yes\n.foo[IS default::Child2] # comment\n" | gel migration create
 !
 ! Please specify a conversion expression to alter the type of link 'foo'.
 ! If left blank, the migration will use the default expression:
-! .foo[IS default::Child2]
 !
-! Cast expression from "default::Child" to "default::Child2" (for ".foo"):
-! cast_expr> 
+!     .foo[IS default::Child2]
+!
+! EdgeQL expression "cast_expr" that resolves into "default::Child2":
+!
 ! Created %{DATA}, id: %{DATA}
  
 $ cat dbschema/migrations/00002-*.edgeql


### PR DESCRIPTION
* Don't leave the default expr in the editor
* Improved the prompt
* Added spacing and highlight to the printed default expr
* Don't replace default expr with user input in the next iteration
* Replaced the highlighted emacs editor with regular textual editor
  * So that ENTER works with empty input (instead of ESC, ENTER or ALT + ENTER)
  * But we lose the syntax highlight, inline error and history
  * I think this is more agent-friendly

Refs #1732

Start with `gel migration create`:

<img width="627" height="444" alt="image" src="https://github.com/user-attachments/assets/0abb1136-ac9b-4745-b84d-e707c5a2be5b" />

### Before:

<img width="888" height="260" alt="image" src="https://github.com/user-attachments/assets/9a1e0c45-d9db-4032-93fe-85102295a893" />
<img width="882" height="396" alt="image" src="https://github.com/user-attachments/assets/5631299f-4bb1-4d32-bb0a-9a07d262c1ff" />

### After:

<img width="891" height="843" alt="image" src="https://github.com/user-attachments/assets/e19280c7-25dd-4c48-b8fa-c112e7ad67b5" />
