### PR TITLE
fix: use readonly lock for `gel generate`

### DIFF
--- a/.github/workflows/new-tests.yml
+++ b/.github/workflows/new-tests.yml
@@ -143,6 +143,9 @@ jobs:
           gel server install
           gel server install --nightly
 
+      - name: Install uv to test with gel generate
+        uses: astral-sh/setup-uv@v6
+
       - name: Run all CLI tests
         run: |
           find tests/scripts -name "*.cli" -type f | while read -r test_file; do

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -11,7 +11,7 @@ use tempfile::NamedTempFile;
 use tokio::process;
 use which::which;
 
-use crate::branding::BRANDING_CLI_CMD;
+use crate::branding::{BRANDING_CLI_CMD, MANIFEST_FILE_DISPLAY_NAME};
 use crate::cli::env::{Env, UseUv};
 use crate::commands::options::Options;
 use crate::hint::HintExt;
@@ -158,7 +158,11 @@ pub async fn prepare_command(
         .split_once('/')
         .context("generator should be of form <lang>/<tool>")?;
 
-    let project = project::ensure_ctx_async(None).await?;
+    let project = project::load_ctx(None, true).await?.ok_or_else(||
+        anyhow::anyhow!(
+            "`{MANIFEST_FILE_DISPLAY_NAME}` not found, unable to perform this action without an initialized project."
+        )
+    )?;
     let mut env = HashMap::new();
     if let Some(config) = project
         .manifest

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -207,7 +207,10 @@ pub async fn prepare_command(
     }
 
     let commands = if lang == "py" {
-        let gen_name = "gel-generate-py";
+        #[cfg(not(windows))]
+        let gen_name = "bin/gel-generate-py";
+        #[cfg(windows)]
+        let gen_name = "Scripts/gel-generate-py.exe";
 
         let mut venv = detect_venv()?;
         let mut using_uv = false;
@@ -229,7 +232,7 @@ pub async fn prepare_command(
                 "Using Python virtual environment: {}",
                 venv.display().to_string().emphasized()
             );
-            let cmd = venv.join("bin").join(gen_name);
+            let cmd = venv.join(gen_name);
             which(&cmd).map_err(|e| {
                 anyhow::anyhow!(e)
                     .context(format!("cannot execute {}", cmd.display()))

--- a/tests/scripts/project/watch.cli
+++ b/tests/scripts/project/watch.cli
@@ -11,7 +11,7 @@ using new dir "watch_test";
 $ gel project init --instance=watch_test --non-interactive
 *
 
-$ uv init
+$ uv init --python 3.12
 *
 
 $ uv add gel==4.0.0b1

--- a/tests/scripts/project/watch.cli
+++ b/tests/scripts/project/watch.cli
@@ -11,6 +11,12 @@ using new dir "watch_test";
 $ gel project init --instance=watch_test --non-interactive
 *
 
+$ uv init
+*
+
+$ uv add gel==4.0.0b1
+*
+
 $ find .
 *
 
@@ -108,4 +114,7 @@ $ sleep 1
 
 $ gel query "select schema::Migration {*} filter .generated_by =
           schema::MigrationGeneratedBy.DevMode;"
+*
+
+$ gel generate py/models
 *


### PR DESCRIPTION
So that `gel generate` runs while `gel watch` is running.

Also fixes to find `Scripts/gel-generate-py.exe` on Windows properly.